### PR TITLE
fix: use standalone RequestExpiredToken in download except clause

### DIFF
--- a/services/base.py
+++ b/services/base.py
@@ -608,7 +608,7 @@ class BaseService:
 
       try:
         result = self.requestUrl(url, destination=filename)
-      except (RequestResult.RequestExpiredToken, RequestInvalidToken):
+      except (RequestExpiredToken, RequestInvalidToken):
         logging.exception('Cannot fetch due to token issues')
         result = RequestResult().setResult(RequestResult.OAUTH_INVALID)
         self._OAUTH = None


### PR DESCRIPTION
Closes #11.

`services/base.py:611` referenced `RequestResult.RequestExpiredToken`, but `RequestExpiredToken` is a standalone exception class imported at line 30, not an attribute of `RequestResult`. Any Immich download timeout raised `AttributeError`, killing the slideshow thread until service restart.

## Test plan
- [x] Already running on Pi 4 for ~17h via uncommitted hand-edit at `/root/photoframe/services/base.py` — captured back into this branch byte-for-byte
- [ ] Post-merge: redeploy from this branch and confirm a forced or organic Immich token expiry produces `Cannot fetch due to token issues` in the journal (not `AttributeError`) and the slideshow keeps cycling