### PR TITLE
fix: register error handler via public API instead of internal dict

### DIFF
--- a/modules/server.py
+++ b/modules/server.py
@@ -69,7 +69,7 @@ class WebServer(Thread):
         logging.getLogger('oauthlib').setLevel(log_level)
         logging.getLogger('urllib3').setLevel(log_level)
 
-        self.app.error_handler_spec = {None: {None : { Exception : self._showException }}}
+        self.app.register_error_handler(Exception, self._showException)
         os.environ['OAUTHLIB_INSECURE_TRANSPORT'] = '1'
         self.app.secret_key = os.urandom(24)
         self._registerHandlers()


### PR DESCRIPTION
Closes #12, closes #8.

`modules/server.py:72` directly assigned Flask's internal `error_handler_spec` dict shape. The internal format changed in newer Flask (shipped with Bookworm: python3-flask 2.2.2), so `_find_error_handler` raised `KeyError: 404` on any 404 (e.g. `/favicon.ico`) and `KeyError: 500` cascaded after.

Switch to `app.register_error_handler(Exception, self._showException)` — the documented public API, stable across Flask versions.

## Test plan
- [x] Already running on Pi 4 for ~17h via uncommitted hand-edit at `/root/photoframe/modules/server.py` — captured back into this branch byte-for-byte
- [ ] Post-merge: redeploy from this branch, hit `http://<pi>:7777/favicon.ico` from a browser, confirm journal shows clean 404 (no `KeyError: 404`/`KeyError: 500` cascade)