### PR TITLE
fix: skip directories in log lookup, fall back to journalctl

### DIFF
--- a/modules/debug.py
+++ b/modules/debug.py
@@ -65,13 +65,26 @@ def logfile(all=False):
     
     log_file = None
     for loc in log_locations:
-        if os.path.exists(loc):
+        if os.path.isfile(loc):
             log_file = loc
             break
     
     if log_file is None:
-        return ('System Log', ['No system log file found in common locations'], None)
-    
+        # No traditional log file found; fall back to journalctl (Bookworm+)
+        try:
+            title = 'Last 100 lines from the photoframe log'
+            cmd = 'journalctl -u frame.service --no-pager -n 100'
+            if all:
+                title = 'Last 100 lines from the system journal'
+                cmd = 'journalctl --no-pager -n 100'
+            lines = subprocess.check_output(cmd, shell=True).decode('utf-8')
+            if lines:
+                lines = lines.splitlines()
+            return (title, lines, '(via journalctl)')
+        except (subprocess.CalledProcessError, OSError, FileNotFoundError) as e:
+            logging.exception('Unable to read journal')
+            return ('System Log', [f'No log file found and journalctl failed: {str(e)}'], None)
+
     try:
         stats = os.stat(log_file)
         cmd = r'grep -a "photoframe\[" ' + log_file + ' | tail -n 100'


### PR DESCRIPTION
Closes #13.

`modules/debug.py:62` used `os.path.exists()` to find a log file, but `exists()` returns True for directories. On Bookworm `/var/log/syslog` is gone and `/var/log/journal` is the systemd journal directory, so the loop selected the directory and `tail` failed with `CalledProcessError`.

- Switch the guard to `os.path.isfile()` so directories are skipped.
- Add a `journalctl` fallback when no traditional log file is found: `frame.service` unit log by default, full system journal when `all=True`. Returns last 100 lines either way.

## Test plan
- [x] Already running on Pi 4 for ~17h via uncommitted hand-edit at `/root/photoframe/modules/debug.py` — captured back into this branch byte-for-byte
- [ ] Post-merge: redeploy from this branch, open the log viewer in the web UI, confirm last 100 lines render (with `(via journalctl)` source label)