### PR TITLE
fix: skip Immich full-res request when ImageMagick policy would refuse it

### DIFF
--- a/services/svc_immich.py
+++ b/services/svc_immich.py
@@ -402,6 +402,10 @@ class Immich(BaseService):
         logging.info(f'Parsed {len(result)} supported images from {len(data)} total assets')
         return result
 
+    # ImageMagick policy limits (from /etc/ImageMagick-6/policy.xml on Bookworm)
+    IMAGEMAGICK_MAX_DIMENSION = 16384  # 16KP width/height limit
+    IMAGEMAGICK_MAX_AREA = 128_000_000  # 128MP area limit
+
     def getContentUrl(self, image, hints):
         config = self.getImmichConfiguration()
         if not config or 'server_url' not in config:
@@ -415,7 +419,7 @@ class Immich(BaseService):
         if image.dimensions:
             width = image.dimensions.get('width', 0)
             height = image.dimensions.get('height', 0)
-            if width > 0 and height > 0 and self._canProcessFullRes(width, height):
+            if width > 0 and height > 0 and self._canProcessImage(width, height):
                 disp = hints.get('display', {}) if hints else {}
                 max_display = max(disp.get('width', 0), disp.get('height', 0))
                 if max_display > 1920:
@@ -425,7 +429,12 @@ class Immich(BaseService):
 
         return f"{config['server_url']}/api/assets/{asset_id}/{endpoint}"
 
-    def _canProcessFullRes(self, width, height):
+    def _canProcessImage(self, width, height):
+        """Check available memory and ImageMagick policy limits."""
+        if width > self.IMAGEMAGICK_MAX_DIMENSION or height > self.IMAGEMAGICK_MAX_DIMENSION:
+            return False
+        if width * height > self.IMAGEMAGICK_MAX_AREA:
+            return False
         estimated_mb = (width * height * 20) / (1024 * 1024)
         safety_buffer_mb = 200
         available_mb = self._getAvailableMemoryMB()


### PR DESCRIPTION
Closes #16.

Bookworm's `/etc/ImageMagick-6/policy.xml` caps width/height at 16KP and area at 128MP. The existing `_canProcessFullRes()` gate only checked available RAM, so on a Pi 4 with 4GB free a 24MP HEIC would pass the RAM check, get downloaded full-res, then `convert` would refuse it and the slideshow would stall on the prior frame.

Rename `_canProcessFullRes` → `_canProcessImage` and add early-return guards for both the per-axis dimension cap and the total-area cap before the existing memory check. When the guard returns False the caller falls back to `thumbnail?size=preview`, which is always safe.

## Test plan
- [x] Already running on Pi 4 for ~17h via uncommitted hand-edit at `/root/photoframe/services/svc_immich.py` — captured back into this branch byte-for-byte
- [ ] Post-merge: redeploy from this branch, point at an album containing a >16KP or >128MP image, confirm slideshow advances past it without stalling