### PR TITLE
fix: resize backdrop to display dims using documented suffix ^

### DIFF
--- a/modules/helper.py
+++ b/modules/helper.py
@@ -236,13 +236,13 @@ class helper:
 				border = f'0x{width_border}'
 				spacing = f'0x{width_spacing}'
 				padding = ((displayHeight - adjHeight) / 2 - width_border)
-				resizeString = f'{adjWidth}x{adjHeight}^'
+				resizeString = f'{displayWidth}x{displayHeight}^'
 				logging.debug(f'Landscape image, reframing (padding required {padding}px)')
 			elif adjWidth < displayWidth:
 				border = f'{width_border}x0'
 				spacing = f'{width_spacing}x0'
 				padding = ((displayWidth - adjWidth) / 2 - width_border)
-				resizeString = f'^{adjWidth}x{adjHeight}'
+				resizeString = f'{displayWidth}x{displayHeight}^'
 				logging.debug(f'Portrait image, reframing (padding required {padding}px)')
 			else:
 				resizeString = f'{adjWidth}x{adjHeight}'


### PR DESCRIPTION
Closes #7.

`makeFullframe`'s backdrop resize used `adjWidth × adjHeight` (the foreground-fit size) as the geometry target, leaving the backdrop short in one axis and producing an undersized framed file that `display.py` then padded with black bars. The portrait branch additionally used undocumented prefix `^` syntax — only suffix `^` is documented in ImageMagick.

Use `displayWidth × displayHeight^` for both branches. Matches upstream `mrworf/photoframe` and produces a correct full-display backdrop across all aspect ratios.

## Verification

- **Empirical (synthetic):** 26 test cases across three displays (1920×1080, 1366×768, 800×480) and nine source aspects produce correct display-sized output with the fix; 0/26 do without.
- **Live on Pi 4 / 1920×1080 HDMI:** confirmed across all relevant code branches:
  - 4:3 — fantastic, blurred margins back
  - 9:16 portrait — looks great
  - Multiple typical portrait shots — consistently good
  - Tall skinny portrait (extreme aspect) — good
  - Panorama (LANDSCAPE branch) — perfect, dimmed-blurred fill on top/bottom

## ImageMagick portability

- Suffix `^` is documented in IM since 6.3.8-3 and stable across Buster (IM 6.9.10.23), Bullseye (6.9.11.60), Bookworm (6.9.11.60). No version-conditional code needed.
- Python-only change — no architecture dependency. Works on Pi 3, Pi 4, Pi Zero.