### PR TITLE
fix: align photoframe.sh on the 'updateonly' arg expected by update.sh

### DIFF
--- a/photoframe.sh
+++ b/photoframe.sh
@@ -26,11 +26,11 @@ fi
 
 # If we never did update, this would be a good time
 if [ ! -f /root/.firstupdate ]; then
-  ./update.sh onlyupdate
+  ./update.sh updateonly
 elif [ -f /boot/forceupdate.txt ]; then
   # If this file is found, force an update on boot,
   # even if we've already done this once
-  ./update.sh onlyupdate
+  ./update.sh updateonly
   rm /boot/forceupdate.txt
 fi
 


### PR DESCRIPTION
Closes #24. Two-line edit: `./update.sh onlyupdate` → `./update.sh updateonly` at photoframe.sh:29 and :33. Aligns the caller with update.sh's check at line 111. `bash -n` clean.