### PR TITLE
fix: restore upstream-matching absolute /root path defaults

### DIFF
--- a/modules/path.py
+++ b/modules/path.py
@@ -20,13 +20,15 @@ import logging
 from pathlib import Path
 
 class path:
-    # Default paths relative to basedir
-    CONFIGFOLDER  = Path('photoframe_config')
+    # Default paths match upstream mrworf/photoframe — runtime data lives at
+    # /root/* (siblings of the repo at /root/photoframe/), keeping the working
+    # tree clean. Use path.reassignBase('.') for in-repo dev workflow.
+    CONFIGFOLDER  = Path('/root/photoframe_config')
     CONFIGFILE    = CONFIGFOLDER / 'settings.json'
     COLORMATCH    = CONFIGFOLDER / 'colortemp.sh'
     OPTIONSFILE   = CONFIGFOLDER / 'options'
-    CACHEFOLDER   = Path('cache')
-    HISTORYFOLDER = Path('history')
+    CACHEFOLDER   = Path('/root/cache')
+    HISTORYFOLDER = Path('/root/history')
 
     DRV_BUILTIN   = Path('display-drivers')
     DRV_EXTERNAL  = CONFIGFOLDER / 'display-drivers'


### PR DESCRIPTION
Closes #22.

Restores `modules/path.py`'s CONFIGFOLDER/CACHEFOLDER/HISTORYFOLDER defaults to upstream-matching `/root/*` absolute paths. Working tree stays clean, `update.sh` egrep no longer trips on Untracked entries, and the boot-time auto-update path becomes functional again.

`reassignBase(newbase)` continues to work — verified `reassignBase('.')` produces relative paths for dev workflow (issue #23 will wire up the CLI/env hook on `dev`).

## Test plan
- [x] `python3 -c 'from modules.path import path; print(path.CONFIGFOLDER)'` → `/root/photoframe_config`
- [x] `reassignBase('.')` produces relative paths for in-checkout dev runs
- [ ] Post-merge: deployment to existing fork-layout Pi requires the migration path on `dev` (#23). DO NOT auto-deploy to existing fork installs without it.