### PR TITLE
chore: cherry-pick today's 7 clean_3x rc1 fixes onto dev

### DIFF
--- a/modules/debug.py
+++ b/modules/debug.py
@@ -65,13 +65,26 @@ def logfile(all=False):
     
     log_file = None
     for loc in log_locations:
-        if os.path.exists(loc):
+        if os.path.isfile(loc):
             log_file = loc
             break
     
     if log_file is None:
-        return ('System Log', ['No system log file found in common locations'], None)
-    
+        # No traditional log file found; fall back to journalctl (Bookworm+)
+        try:
+            title = 'Last 100 lines from the photoframe log'
+            cmd = 'journalctl -u frame.service --no-pager -n 100'
+            if all:
+                title = 'Last 100 lines from the system journal'
+                cmd = 'journalctl --no-pager -n 100'
+            lines = subprocess.check_output(cmd, shell=True).decode('utf-8')
+            if lines:
+                lines = lines.splitlines()
+            return (title, lines, '(via journalctl)')
+        except (subprocess.CalledProcessError, OSError, FileNotFoundError) as e:
+            logging.exception('Unable to read journal')
+            return ('System Log', [f'No log file found and journalctl failed: {str(e)}'], None)
+
     try:
         stats = os.stat(log_file)
         cmd = r'grep -a "photoframe\[" ' + log_file + ' | tail -n 100'

--- a/modules/helper.py
+++ b/modules/helper.py
@@ -236,13 +236,13 @@ class helper:
 				border = f'0x{width_border}'
 				spacing = f'0x{width_spacing}'
 				padding = ((displayHeight - adjHeight) / 2 - width_border)
-				resizeString = f'{adjWidth}x{adjHeight}^'
+				resizeString = f'{displayWidth}x{displayHeight}^'
 				logging.debug(f'Landscape image, reframing (padding required {padding}px)')
 			elif adjWidth < displayWidth:
 				border = f'{width_border}x0'
 				spacing = f'{width_spacing}x0'
 				padding = ((displayWidth - adjWidth) / 2 - width_border)
-				resizeString = f'^{adjWidth}x{adjHeight}'
+				resizeString = f'{displayWidth}x{displayHeight}^'
 				logging.debug(f'Portrait image, reframing (padding required {padding}px)')
 			else:
 				resizeString = f'{adjWidth}x{adjHeight}'

--- a/modules/path.py
+++ b/modules/path.py
@@ -20,13 +20,15 @@ import logging
 from pathlib import Path
 
 class path:
-    # Default paths relative to basedir
-    CONFIGFOLDER  = Path('photoframe_config')
+    # Default paths match upstream mrworf/photoframe — runtime data lives at
+    # /root/* (siblings of the repo at /root/photoframe/), keeping the working
+    # tree clean. Use path.reassignBase('.') for in-repo dev workflow.
+    CONFIGFOLDER  = Path('/root/photoframe_config')
     CONFIGFILE    = CONFIGFOLDER / 'settings.json'
     COLORMATCH    = CONFIGFOLDER / 'colortemp.sh'
     OPTIONSFILE   = CONFIGFOLDER / 'options'
-    CACHEFOLDER   = Path('cache')
-    HISTORYFOLDER = Path('history')
+    CACHEFOLDER   = Path('/root/cache')
+    HISTORYFOLDER = Path('/root/history')
 
     DRV_BUILTIN   = Path('display-drivers')
     DRV_EXTERNAL  = CONFIGFOLDER / 'display-drivers'

--- a/modules/server.py
+++ b/modules/server.py
@@ -69,7 +69,7 @@ class WebServer(Thread):
         logging.getLogger('oauthlib').setLevel(log_level)
         logging.getLogger('urllib3').setLevel(log_level)
 
-        self.app.error_handler_spec = {None: {None : { Exception : self._showException }}}
+        self.app.register_error_handler(Exception, self._showException)
         os.environ['OAUTHLIB_INSECURE_TRANSPORT'] = '1'
         self.app.secret_key = os.urandom(24)
         self._registerHandlers()

--- a/photoframe.sh
+++ b/photoframe.sh
@@ -26,11 +26,11 @@ fi
 
 # If we never did update, this would be a good time
 if [ ! -f /root/.firstupdate ]; then
-  ./update.sh onlyupdate
+  ./update.sh updateonly
 elif [ -f /boot/forceupdate.txt ]; then
   # If this file is found, force an update on boot,
   # even if we've already done this once
-  ./update.sh onlyupdate
+  ./update.sh updateonly
   rm /boot/forceupdate.txt
 fi
 

--- a/services/base.py
+++ b/services/base.py
@@ -618,7 +618,7 @@ class BaseService:
 
       try:
         result = self.requestUrl(url, destination=filename)
-      except (RequestResult.RequestExpiredToken, RequestInvalidToken):
+      except (RequestExpiredToken, RequestInvalidToken):
         logging.exception('Cannot fetch due to token issues')
         result = RequestResult().setResult(RequestResult.OAUTH_INVALID)
         self._OAUTH = None

--- a/services/svc_immich.py
+++ b/services/svc_immich.py
@@ -404,6 +404,10 @@ class Immich(BaseService):
         logging.info(f'Parsed {len(result)} supported images from {len(data)} total assets')
         return result
 
+    # ImageMagick policy limits (from /etc/ImageMagick-6/policy.xml on Bookworm)
+    IMAGEMAGICK_MAX_DIMENSION = 16384  # 16KP width/height limit
+    IMAGEMAGICK_MAX_AREA = 128_000_000  # 128MP area limit
+
     def getContentUrl(self, image, hints):
         config = self.getImmichConfiguration()
         if not config or 'server_url' not in config:
@@ -417,7 +421,7 @@ class Immich(BaseService):
         if image.dimensions:
             width = image.dimensions.get('width', 0)
             height = image.dimensions.get('height', 0)
-            if width > 0 and height > 0 and self._canProcessFullRes(width, height):
+            if width > 0 and height > 0 and self._canProcessImage(width, height):
                 disp = hints.get('display', {}) if hints else {}
                 max_display = max(disp.get('width', 0), disp.get('height', 0))
                 if max_display > 1920:
@@ -427,7 +431,12 @@ class Immich(BaseService):
 
         return f"{config['server_url']}/api/assets/{asset_id}/{endpoint}"
 
-    def _canProcessFullRes(self, width, height):
+    def _canProcessImage(self, width, height):
+        """Check available memory and ImageMagick policy limits."""
+        if width > self.IMAGEMAGICK_MAX_DIMENSION or height > self.IMAGEMAGICK_MAX_DIMENSION:
+            return False
+        if width * height > self.IMAGEMAGICK_MAX_AREA:
+            return False
         estimated_mb = (width * height * 20) / (1024 * 1024)
         safety_buffer_mb = 200
         available_mb = self._getAvailableMemoryMB()


### PR DESCRIPTION
Brings clean_3x's v3.0.0-rc1 fixes onto dev as the foundation for ongoing fork work.

## Cherry-picked (chronological)
| New SHA | Original | Closes |
|---|---|---|
| `a2957d8` | `c088b76` | #11 RequestExpiredToken AttributeError |
| `1cc7faa` | `58bff9e` | #12, #8 Flask error handler API |
| `f3f940e` | `8dcd768` | #13 log viewer journalctl fallback |
| `19ca1d7` | `2dcf454` | #16 Immich ImageMagick policy guard |
| `98c4c3d` | `21255d3` | #7 makeFullframe blur backdrop dims |
| `55d0099` | `3fa32a9` | #24 photoframe.sh updateonly typo |
| `b4d4342` | `a8031f3` | #22 path defaults restored to /root/* |

## Known tradeoff
The path.py cherry-pick (#22) restores absolute `/root/*` defaults. On dev, in-checkout workflow now requires either running as root OR calling `path.reassignBase('.')` until #23 wires `PHOTOFRAME_BASEDIR` env var to that method. Issue #23 is the next dev work and addresses this.

All cherry-picks applied without conflict.