### PR TITLE
feat: surface display diagnostics on /debug endpoint

### DIFF
--- a/frame.py
+++ b/frame.py
@@ -149,6 +149,7 @@ class Photoframe:
     self._loadRoute('service', 'RouteService', self.serviceMgr, self.slideshow)
     self._loadRoute('control', 'RouteControl', self.slideshow)
     self._loadRoute('events', 'RouteEvents', self.eventMgr)
+    self._loadRoute('debug', 'RouteDebug', self.displayMgr)
 
   def validateSettings(self):
     if not self.settingsMgr.load():

--- a/modules/debug.py
+++ b/modules/debug.py
@@ -101,6 +101,23 @@ def logfile(all=False):
         logging.exception('Unable to read log file')
         return (title, [f'Unable to read log file: {str(e)}'], None)
 
+def display_diagnostics(displaymgr):
+    title = 'Display diagnostics'
+    lines = []
+    try:
+        d = displaymgr.get_display_diagnostics()
+        for k, v in d.items():
+            if isinstance(v, dict):
+                lines.append(f'{k}:')
+                for sk, sv in v.items():
+                    lines.append(f'  {sk}: {sv}')
+            else:
+                lines.append(f'{k}: {v}')
+    except Exception as e:
+        logging.exception('Unable to read display diagnostics')
+        lines = [f'Unable to read display diagnostics: {str(e)}']
+    return (title, lines, None)
+
 def version():
     title = 'Running version'
     try:

--- a/routes/debug.py
+++ b/routes/debug.py
@@ -20,10 +20,9 @@ import modules.debug as debug
 from .baseroute import BaseRoute
 
 class RouteDebug(BaseRoute):
-  SIMPLE = True # We have no dependencies to the rest of the system
-
-  def setup(self):
-    self.addUrl('/debug')    
+  def setupex(self, displaymgr):
+    self.displaymgr = displaymgr
+    self.addUrl('/debug')
 
   def handle(self, app, **kwargs):
     # Special URL, we simply try to extract latest 100 lines from syslog
@@ -33,6 +32,7 @@ class RouteDebug(BaseRoute):
     report.append(debug.version())
     report.append(debug.logfile(False))
     report.append(debug.logfile(True))
+    report.append(debug.display_diagnostics(self.displaymgr))
     report.append(debug.stacktrace())
 
     message = '<html><head><title>Photoframe Log Report</title></head><body style="font-family: Verdana">'


### PR DESCRIPTION
Closes #14. Wires `display.get_display_diagnostics()` (previously dead code) into the `/debug` page report. New `debug.display_diagnostics(displaymgr)` helper formats the dict; route plumbed via `setupex` to the live display instance.