### PR TITLE
chore: cherry-pick e9e2ad9 + 1d171c0 from clean_3x onto dev

### DIFF
--- a/frame.service
+++ b/frame.service
@@ -15,7 +15,7 @@
 #
 [Unit]
 Description=Photo Frame
-After=network.target
+After=network.target lightdm.service
 
 [Service]
 Type=simple

--- a/modules/display.py
+++ b/modules/display.py
@@ -750,6 +750,9 @@ class display:
             if enable:
                 logging.info('Modern display enable: taking control from desktop environment')
                 
+                # Stop the display manager (Bookworm desktop ships lightdm; harmless no-op on Lite)
+                debug.subprocess_call(['sudo', 'systemctl', 'stop', 'lightdm.service'], stderr=self.void)
+
                 # Kill any running desktop environment processes that might interfere
                 debug.subprocess_call(['sudo', 'pkill', '-f', 'lxsession'], stderr=self.void)
                 debug.subprocess_call(['sudo', 'pkill', '-f', 'openbox'], stderr=self.void)

--- a/modules/slideshow.py
+++ b/modules/slideshow.py
@@ -183,7 +183,7 @@ class slideshow:
   def waitForNetwork(self):
     self.imageCurrent = None
     helper.waitForNetwork(
-      lambda: self.display.message('No internet connection\n\nCheck router, wifi-config.txt or cable'),
+      lambda: self.display.message('No internet connection\n\nCheck router, /boot/firmware/wifi-config.txt, or cable'),
       lambda: self.settings.getUser('offline-behavior') != 'wait'
     )
     self.display.setConfigPage(f'http://{helper.getDeviceIp()}:7777/')


### PR DESCRIPTION
Brings two clean_3x commits that were missed by the earlier today-only cherry-pick batch.

| New SHA | Original | What |
|---|---|---|
| (cherry-picked) | e9e2ad9 | display: stop lightdm + frame.service After= ordering for Bookworm desktop |
| (cherry-picked) | 1d171c0 | slideshow: clarify wifi-config.txt path in no-network error message |

Audit: `git cherry HEAD origin/clean_3x` after these land shows all clean_3x commits as patch-equivalent to commits already on dev, except 6d2805c ("Remove tracked .claude/CLAUDE.md") — which is content-equivalent because dev's e065c7a already removed the file as part of a broader cleanup; cherry-picking it would be a no-op.