### PR TITLE
ci: LITE image build workflow for release assets

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -19,6 +19,12 @@ on:
 permissions:
   contents: write
 
+# Serialize builds per tag — release artifacts are valuable, don't cancel
+# in-flight builds when a re-dispatch happens for the same tag.
+concurrency:
+  group: build-image-${{ github.event.inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   build-lite:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,96 @@
+name: Build Photoframe LITE image
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Photoframe tag to build (e.g. v3.0.0-rc1). Tag must already exist.'
+        required: true
+        type: string
+      pi_gen_ref:
+        description: 'dev-brewery/pi-gen ref to build with'
+        required: false
+        type: string
+        default: bookworm-photoframe
+
+permissions:
+  contents: write
+
+jobs:
+  build-lite:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    env:
+      PHOTOFRAME_TAG: ${{ github.event.inputs.tag || github.ref_name }}
+      PI_GEN_REF: ${{ github.event.inputs.pi_gen_ref || 'bookworm-photoframe' }}
+
+    steps:
+      - name: Free disk space on runner
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                      /opt/hostedtoolcache/CodeQL /usr/local/share/boost
+          sudo docker image prune -af || true
+          df -h /
+
+      - name: Check out photoframe at tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.PHOTOFRAME_TAG }}
+          path: photoframe
+
+      - name: Check out dev-brewery/pi-gen
+        uses: actions/checkout@v4
+        with:
+          repository: dev-brewery/pi-gen
+          ref: ${{ env.PI_GEN_REF }}
+          path: pi-gen
+
+      - name: Write pi-gen config
+        working-directory: pi-gen
+        run: |
+          cp config.example config
+          cat >> config <<EOF
+
+          # --- Injected by photoframe CI ---
+          # Use the checked-out tag as the source tree instead of cloning
+          # the branch referenced by PHOTOFRAME_BRANCH over the network.
+          PHOTOFRAME_SRC=${GITHUB_WORKSPACE}/photoframe
+          IMG_NAME='photoframe-${PHOTOFRAME_TAG}'
+          EOF
+          echo "--- final config ---"
+          cat config
+
+      - name: Build LITE image
+        working-directory: pi-gen
+        run: ./build-docker.sh lite
+
+      - name: Compress image
+        working-directory: pi-gen/deploy
+        run: |
+          ls -lah
+          for img in *.img; do
+            [ -e "$img" ] || continue
+            xz -9 -T0 -v "$img"
+          done
+          ls -lah
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: photoframe-image-${{ env.PHOTOFRAME_TAG }}
+          path: pi-gen/deploy/*.img.xz
+          retention-days: 14
+          if-no-files-found: error
+
+      - name: Attach .img.xz to release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.PHOTOFRAME_TAG }}
+          prerelease: ${{ contains(env.PHOTOFRAME_TAG, '-rc') || contains(env.PHOTOFRAME_TAG, '-beta') || contains(env.PHOTOFRAME_TAG, '-alpha') }}
+          files: pi-gen/deploy/*.img.xz
+          fail_on_unmatched_files: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/build-image.yml`: on `v*` tag push (and manual dispatch), builds a Raspberry Pi OS Bookworm **LITE** image with photoframe pre-installed using [`dev-brewery/pi-gen@bookworm-photoframe`](https://github.com/dev-brewery/pi-gen/tree/bookworm-photoframe), xz-compresses the output, and attaches `.img.xz` to the matching release.
- Pre-release tags (`-rc`, `-beta`, `-alpha`) are marked prerelease on the release object.
- Uses pi-gen's `PHOTOFRAME_SRC` knob so the build consumes the checked-out tag, not whatever `PHOTOFRAME_BRANCH` is pinned to in `config.example`.
- Manual dispatch takes a `tag` input (required) and an optional `pi_gen_ref` override.

## Why

Closes the gap raised on the v3.0.0-rc1 release — users should be able to flash a ready-to-go image from the release page instead of bootstrapping from `install.sh`.

## Test plan

- [ ] Merge this PR.
- [ ] Manually dispatch the workflow with `tag = v3.0.0-rc1` (tag already exists).
- [ ] Verify a `photoframe-v3.0.0-rc1-*-lite.img.xz` asset lands on the v3.0.0-rc1 release page.
- [ ] Flash to SD, boot a Pi, confirm `frame.service` comes up and the web UI is reachable.
- [ ] (Next tag) Confirm auto-trigger on `v*` push produces the asset without manual dispatch.

## Notes

- Build runtime is ~50 min on `ubuntu-latest` per pi-gen's `BUILD.md`.
- Runner disk cleanup step is present because pi-gen needs ~10 GB free and `ubuntu-latest` ships full of preinstalled SDKs.