### PR TITLE
ci: register QEMU binfmt handlers before pi-gen build

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -41,6 +41,16 @@ jobs:
           sudo docker image prune -af || true
           df -h /
 
+      # Register qemu-user-static handlers in the host kernel's binfmt_misc
+      # so pi-gen's build.sh can execute the armhf rootfs binaries under
+      # emulation. pi-gen's in-container `dpkg-reconfigure qemu-user-static`
+      # does not reliably set up the handlers on stock ubuntu-latest; doing
+      # it here on the host is the standard Actions pattern.
+      - name: Register QEMU binfmt handlers (armhf/arm64)
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm,arm64
+
       - name: Check out photoframe at tag
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

First v3.0.0-rc1 dispatch ([run 24578724566](https://github.com/dev-brewery/photoframe/actions/runs/24578724566)) failed ~2 min in:

```
Checking native armhf executable support...
armhf: not supported on this machine/kernel
No fallback mechanism found. Ensure your OS has binfmt_misc support enabled and configured.
[17:45:05] Build failed
```

pi-gen's `build-docker.sh` tries to register qemu handlers from inside the `--privileged` container via `dpkg-reconfigure qemu-user-static`, but on stock `ubuntu-latest` that doesn't actually populate the host kernel's `binfmt_misc`. Adding `docker/setup-qemu-action@v3` as a pre-build step (the standard Actions pattern — uses `tonistiigi/binfmt` to register handlers on the host) makes the armhf binaries executable by the time pi-gen's build.sh does its support check.

## Test plan

- [ ] Merge this PR.
- [ ] Re-dispatch `build-image.yml` with `tag = v3.0.0-rc1`.
- [ ] Confirm the run gets past the "Checking native armhf executable support" check and into the pi-gen stages.
- [ ] Verify `.img.xz` lands on the v3.0.0-rc1 release page.