### PR TITLE
ci: adapt to pi-gen's native image_*.zip output

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -83,30 +83,28 @@ jobs:
         working-directory: pi-gen
         run: ./build-docker.sh lite
 
-      - name: Compress image
+      - name: List deploy output
         working-directory: pi-gen/deploy
-        run: |
-          ls -lah
-          for img in *.img; do
-            [ -e "$img" ] || continue
-            xz -9 -T0 -v "$img"
-          done
-          ls -lah
+        run: ls -lah
 
+      # pi-gen's default DEPLOY_COMPRESSION=zip emits image_<IMG_NAME>-lite.zip.
+      # Pi Imager consumes .zip natively, so ship what pi-gen produces.
       - name: Upload workflow artifact
         uses: actions/upload-artifact@v4
         with:
           name: photoframe-image-${{ env.PHOTOFRAME_TAG }}
-          path: pi-gen/deploy/*.img.xz
+          path: pi-gen/deploy/image_*.zip
           retention-days: 14
           if-no-files-found: error
 
-      - name: Attach .img.xz to release
+      - name: Attach image to release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ env.PHOTOFRAME_TAG }}
           prerelease: ${{ contains(env.PHOTOFRAME_TAG, '-rc') || contains(env.PHOTOFRAME_TAG, '-beta') || contains(env.PHOTOFRAME_TAG, '-alpha') }}
-          files: pi-gen/deploy/*.img.xz
+          files: |
+            pi-gen/deploy/image_*.zip
+            pi-gen/deploy/*.info
           fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Run [24587004558](https://github.com/dev-brewery/photoframe/actions/runs/24587004558) built successfully (48m23s, all 6 pi-gen stages ran) but failed at the upload step — my workflow globbed for `*.img.xz` while pi-gen's default deploy emits `image_<IMG_NAME>-lite.zip`:

```
drwxr-xr-x 2 runner runner 4.0K Apr 17 22:03 .
-rw-r--r-- 1 runner runner 102K 2026-04-17-photoframe-v3.0.0-rc1-lite.info
-rw-r--r-- 1 runner runner 404K build-docker.log
-rw-r--r-- 1 runner runner 6.4K build.log
-rw-r--r-- 1 runner runner 813M image_2026-04-17-photoframe-v3.0.0-rc1-lite.zip
##[error]No files were found with the provided path: pi-gen/deploy/*.img.xz.
```

Raspberry Pi Imager consumes `.zip` natively, so the right move is to ship what pi-gen produces rather than force `DEPLOY_COMPRESSION=xz` and duplicate the compression work.

## Changes

- Glob `pi-gen/deploy/image_*.zip` for artifact + release upload.
- Also attach the `*.info` SBOM-style manifest pi-gen writes alongside the zip.
- Drop the `Compress image` step; keep one `ls -lah` as a post-build manifest for future troubleshooting.

## Test plan

- [ ] Merge this PR.
- [ ] Re-dispatch `build-image.yml` with `tag = v3.0.0-rc1`.
- [ ] Confirm the `image_*.zip` asset (~813 MB) lands on the v3.0.0-rc1 release page.
- [ ] Verify in Pi Imager that the zip is recognized as a flashable image.