### PR TITLE
ci: forward-port image build workflow from clean_3x

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -83,30 +83,28 @@ jobs:
         working-directory: pi-gen
         run: ./build-docker.sh lite
 
-      - name: Compress image
+      - name: List deploy output
         working-directory: pi-gen/deploy
-        run: |
-          ls -lah
-          for img in *.img; do
-            [ -e "$img" ] || continue
-            xz -9 -T0 -v "$img"
-          done
-          ls -lah
+        run: ls -lah
 
+      # pi-gen's default DEPLOY_COMPRESSION=zip emits image_<IMG_NAME>-lite.zip.
+      # Pi Imager consumes .zip natively, so ship what pi-gen produces.
       - name: Upload workflow artifact
         uses: actions/upload-artifact@v4
         with:
           name: photoframe-image-${{ env.PHOTOFRAME_TAG }}
-          path: pi-gen/deploy/*.img.xz
+          path: pi-gen/deploy/image_*.zip
           retention-days: 14
           if-no-files-found: error
 
-      - name: Attach .img.xz to release
+      - name: Attach image to release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ env.PHOTOFRAME_TAG }}
           prerelease: ${{ contains(env.PHOTOFRAME_TAG, '-rc') || contains(env.PHOTOFRAME_TAG, '-beta') || contains(env.PHOTOFRAME_TAG, '-alpha') }}
-          files: pi-gen/deploy/*.img.xz
+          files: |
+            pi-gen/deploy/image_*.zip
+            pi-gen/deploy/*.info
           fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -19,6 +19,12 @@ on:
 permissions:
   contents: write
 
+# Serialize builds per tag — release artifacts are valuable, don't cancel
+# in-flight builds when a re-dispatch happens for the same tag.
+concurrency:
+  group: build-image-${{ github.event.inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   build-lite:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,96 @@
+name: Build Photoframe LITE image
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Photoframe tag to build (e.g. v3.0.0-rc1). Tag must already exist.'
+        required: true
+        type: string
+      pi_gen_ref:
+        description: 'dev-brewery/pi-gen ref to build with'
+        required: false
+        type: string
+        default: bookworm-photoframe
+
+permissions:
+  contents: write
+
+jobs:
+  build-lite:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    env:
+      PHOTOFRAME_TAG: ${{ github.event.inputs.tag || github.ref_name }}
+      PI_GEN_REF: ${{ github.event.inputs.pi_gen_ref || 'bookworm-photoframe' }}
+
+    steps:
+      - name: Free disk space on runner
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                      /opt/hostedtoolcache/CodeQL /usr/local/share/boost
+          sudo docker image prune -af || true
+          df -h /
+
+      - name: Check out photoframe at tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.PHOTOFRAME_TAG }}
+          path: photoframe
+
+      - name: Check out dev-brewery/pi-gen
+        uses: actions/checkout@v4
+        with:
+          repository: dev-brewery/pi-gen
+          ref: ${{ env.PI_GEN_REF }}
+          path: pi-gen
+
+      - name: Write pi-gen config
+        working-directory: pi-gen
+        run: |
+          cp config.example config
+          cat >> config <<EOF
+
+          # --- Injected by photoframe CI ---
+          # Use the checked-out tag as the source tree instead of cloning
+          # the branch referenced by PHOTOFRAME_BRANCH over the network.
+          PHOTOFRAME_SRC=${GITHUB_WORKSPACE}/photoframe
+          IMG_NAME='photoframe-${PHOTOFRAME_TAG}'
+          EOF
+          echo "--- final config ---"
+          cat config
+
+      - name: Build LITE image
+        working-directory: pi-gen
+        run: ./build-docker.sh lite
+
+      - name: Compress image
+        working-directory: pi-gen/deploy
+        run: |
+          ls -lah
+          for img in *.img; do
+            [ -e "$img" ] || continue
+            xz -9 -T0 -v "$img"
+          done
+          ls -lah
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: photoframe-image-${{ env.PHOTOFRAME_TAG }}
+          path: pi-gen/deploy/*.img.xz
+          retention-days: 14
+          if-no-files-found: error
+
+      - name: Attach .img.xz to release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.PHOTOFRAME_TAG }}
+          prerelease: ${{ contains(env.PHOTOFRAME_TAG, '-rc') || contains(env.PHOTOFRAME_TAG, '-beta') || contains(env.PHOTOFRAME_TAG, '-alpha') }}
+          files: pi-gen/deploy/*.img.xz
+          fail_on_unmatched_files: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -41,6 +41,16 @@ jobs:
           sudo docker image prune -af || true
           df -h /
 
+      # Register qemu-user-static handlers in the host kernel's binfmt_misc
+      # so pi-gen's build.sh can execute the armhf rootfs binaries under
+      # emulation. pi-gen's in-container `dpkg-reconfigure qemu-user-static`
+      # does not reliably set up the handlers on stock ubuntu-latest; doing
+      # it here on the host is the standard Actions pattern.
+      - name: Register QEMU binfmt handlers (armhf/arm64)
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm,arm64
+
       - name: Check out photoframe at tag
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

Brings the four image-build CI commits from `clean_3x` into `dev` so the workflow rides the normal `dev → master` PR flow into master for the next release. Without this, `dev` lands on master without `.github/workflows/build-image.yml`, and the first tag cut off master ships without a flashable image attached — same gap we just climbed out of on rc1.

## Commits (cherry-picked in order, clean — no conflicts)

| commit on this branch | source on clean_3x | what |
|---|---|---|
| `7f5c21f` | `4ccd000` | Add the workflow — triggers on `v*` tags + manual dispatch, builds with `dev-brewery/pi-gen@bookworm-photoframe`, uploads to the matching release |
| `dedc0d9` | `2d1f014` | Serialize per-tag builds via concurrency group (no cancel-in-progress for release artifacts) |
| `1e61944` | `a880e66` | `docker/setup-qemu-action@v3` to register armhf binfmt handlers on the host |
| `87b3abc` | `f676da8` (#37) | Consume pi-gen's native `image_*.zip` instead of coercing `DEPLOY_COMPRESSION=xz` |

`clean_3x` is frozen, so these won't reach master any other way.

## Test plan

- [ ] Merge when convenient — no behavioural change until a `v*` tag lands on master (or until master becomes the default and someone manually dispatches).
- [ ] Next release cycle: when `dev` PRs to master, `.github/workflows/build-image.yml` comes along. GitHub registers the workflow on the default branch. Tagging a release then auto-builds the image and attaches it.

## Validation

Workflow as written was validated locally on WSL2 Docker for v3.0.0-rc1 (45m24s build, produced `image_*.zip` with matching `.info` — the exact asset now attached to the rc1 release).