### PR TITLE
docs: rewrite README and MANUAL for Bookworm/Python 3 reality

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1,127 +1,305 @@
-# Manual installation
+# Manual installation (Raspberry Pi OS Bookworm + Python 3)
 
-First, install your favorite debian distro (recommend minibian, https://minibianpi.wordpress.com/ )
+> **Most users should not read this document.** The two easier paths:
+>
+> 1. Download the pre-built SD card image from the [releases page](https://github.com/dev-brewery/photoframe/releases), flash, edit `wifi-config.txt`, boot. Covered as Option 2 in the [README](README.md).
+> 2. Run [`install.sh`](install.sh) on a fresh Raspberry Pi OS Lite install. Covered as Option 1 in the README.
+>
+> This document is for users who want to understand every step, or who need to reproduce the install on a system where the scripted path doesn't fit. Everything here is also documented in `install.sh` as executable code.
+>
+> The pre-Bookworm install process (minibian, Python 2, `/etc/network/interfaces`) is no longer supported and is preserved only in git history (`git log -- MANUAL.md` against earlier refs).
 
-NOTE!
-Photoframe requires about 1GB of storage due to all dependencies. If you're using minibian, please see https://minibianpi.wordpress.com/how-to/resize-sd/ for instructions on how to resize the root filesystem.
+First, install **Raspberry Pi OS Lite (Bookworm)** on your SD card using
+[Raspberry Pi Imager](https://www.raspberrypi.com/software/). The Lite
+variant is the right choice — photoframe is a framebuffer application
+and writes directly to `/dev/fb0`, so a desktop environment would
+actively compete with it for the display. Do **not** use Desktop or Full.
 
-Make your distro of choice is up-to-date by issuing
+When Imager offers its "advanced settings" gear icon, use it to set:
+- **Username and password** (anything you like — these are yours)
+- **SSH enabled**
+- **WiFi credentials** and the **WiFi country code**
+- **Hostname** (optional, defaults to `raspberrypi`)
+- **Locale and timezone**
 
-`apt update && apt upgrade`
+Imager bakes these into the image before writing, so when you boot,
+the Pi is on your WiFi with SSH ready. If you skip the gear icon, you
+will need to configure WiFi and SSH manually after boot, which this
+guide covers in the `# wifi setup` section below.
 
-Once done, we need to install all dependencies
+Photoframe and its dependencies require about **1 GB** of space.
+Bookworm Lite is about 3 GB after first boot, so a 4 GB SD card is the
+absolute minimum — 8 GB or larger is comfortable.
 
-`apt install apt-utils raspi-config git fbset python python-requests python-requests-oauthlib python-flask python-flask-httpauth imagemagick python-smbus bc`
-
-Next, let's tweak the boot so we don't get a bunch of output
-
-Edit the `/boot/cmdline.txt` and add the following to the end of the line:
+Make your install up to date by issuing
 
 ```
-console=tty3 loglevel=3 consoleblank=0 vt.global_cursor_default=0 logo.nologo
+sudo apt update && sudo apt upgrade
 ```
 
-You also need to edit the `/boot/config.txt`
+Once done, install all dependencies. The package list below is lifted
+from `stage2/04-photoframe/00-packages` in the
+[`dev-brewery/pi-gen`](https://github.com/dev-brewery/pi-gen) fork and
+matches exactly what the pre-built image ships with:
 
-Add the following
+```
+sudo apt install apt-utils raspi-config git bc openssh-server \
+    python3 python3-pip python3-smbus \
+    fbset imagemagick libheif-examples libjpeg-turbo-progs \
+    rng-tools-debian
+```
+
+**Python 3 note:** Bookworm enforces
+[PEP 668](https://peps.python.org/pep-0668/) and refuses `pip` installs
+into the system Python environment without explicit opt-in. Photoframe
+needs its dependencies globally installed (the `frame` systemd service
+runs them as root), so we pass the `--break-system-packages` flag when
+running pip. This is intentional, not a mistake. See the photoframe
+install command block below.
+
+Next, let's tweak the boot config so the framebuffer is free for
+photoframe to take over. On Bookworm, the boot-partition config files
+live at `/boot/firmware/`, not `/boot/` (which was the Bullseye-era
+path). Edit **`/boot/firmware/config.txt`** and add:
 
 ```
 disable_splash=1
 framebuffer_ignore_alpha=1
 ```
 
-We also want to disable the first console (since that's going to be our frame). This is done by
-issuing
+If you plan to use the TCS34725 color-temperature sensor (see the
+README's `color temperature?` section), also add:
 
 ```
-systemctl disable getty@tty1.service
+dtparam=i2c_arm=on
 ```
 
-If you're using a rasbian (or a varity of said distro) you may need to also do
+**Atypical HDMI displays:** if you're driving a non-standard panel —
+for example, an old laptop LCD via an HDMI-to-LVDS adapter board that
+doesn't report a proper EDID — you need to force a specific video mode
+on the kernel command line. Edit **`/boot/firmware/cmdline.txt`** (a
+single-line file; do NOT add newlines) and append this to the end of
+the existing line, with a leading space:
 
 ```
-systemctl mask plymouth-start.service
+video=HDMI-A-1:1366x768MR@60D
 ```
 
-or you might still see the boot messages.
+Replace `1366x768` with your panel's native resolution. Flag meanings:
+`M` = CVT timings, `R` = reduced blanking, `@60` = refresh rate,
+`D` = force DVI output and treat the port as connected even without
+HPD (required because most HDMI-to-LVDS adapter boards don't assert
+HPD). On Bookworm's KMS driver, the legacy `hdmi_group` / `hdmi_mode`
+/ `hdmi_cvt` options in `config.txt` are **silently ignored** — the
+only file that matters for forcing a video mode is `cmdline.txt`.
 
-Almost there, we also need to set the timezone for the device, or it will be confusing when the on/off hours doesn't meet expectations.
+**If you have a normal HDMI monitor**, skip the cmdline.txt edit
+entirely. EDID auto-detection works correctly for the overwhelming
+majority of displays.
+
+We also want to disable the first console (since that's going to be
+our frame) and mask the boot splash:
 
 ```
-timedatectl set-timezone America/Los_Angeles
+sudo systemctl disable getty@tty1.service
+sudo systemctl mask plymouth-start.service
 ```
 
-If you don't know your timezone, you can list all supported
+Both are needed. `getty@tty1.service` would otherwise print a login
+prompt on the framebuffer, and `plymouth-start.service` would flash a
+Raspberry Pi boot splash that fights photoframe for the display.
+
+Set the timezone so the on/off hours schedule makes sense:
+
+```
+sudo timedatectl set-timezone America/Los_Angeles
+```
+
+If you don't know your timezone, list all supported values:
 
 ```
 timedatectl list-timezones
 ```
 
-Finally, time to install photoframe, which means downloading the repo, install the service and reboot
+Finally, install photoframe. The repo to clone is
+`dev-brewery/photoframe` (the maintained fork), not the original
+`mrworf/photoframe` which is unmaintained and pre-Python-3.
 
 ```
+sudo su -
 cd /root
 git clone https://github.com/dev-brewery/photoframe.git
 cd photoframe
+pip3 install --break-system-packages -r requirements.txt
 cp frame.service /etc/systemd/system/
 systemctl enable /etc/systemd/system/frame.service
+```
+
+Add the `i2c-dev` kernel module to `/etc/modules` so the color sensor
+(if you're using one) works on next boot:
+
+```
+grep -q '^i2c-dev$' /etc/modules || echo 'i2c-dev' >> /etc/modules
+```
+
+And reboot:
+
+```
 reboot
 ```
 
-Done! Once the device has rebooted, it will tell you how to connect to it and then using your webbrowser you can link it to Google Photos.
+Done! Once the device has rebooted, the photoframe web UI is hosted on
+port 7777. Find the Pi's IP address (check your router's DHCP table or
+try `ping raspberrypi.local` if your network supports mDNS), then open
+`http://<pi-ip>:7777` in your browser. The default web UI credentials
+are `photoframe` / `password` (change via `http-auth.json` in
+`/root/photoframe_config/`). Choose your photo service (Immich is the
+supported default; Google Photos is deprecated) and follow the prompts.
 
 # wifi setup
 
-This requires a couple of extra steps, first we need more software
+**Bookworm uses NetworkManager** for all network configuration. The
+legacy `/etc/network/interfaces` + `wpa_supplicant.conf` approach that
+the original MANUAL.md documented is no longer supported — those files
+exist but are not read by the active network stack on a standard
+Bookworm Lite install. If you want to configure WiFi from scratch on
+a Bookworm system, use NetworkManager.
+
+**The easiest path** is Raspberry Pi Imager's gear icon during initial
+flashing. See the note at the top of this document.
+
+**If you skipped the gear icon** and need to configure WiFi after boot,
+you have two options:
+
+## Option A: Interactive via `nmtui`
+
+This is the friendliest manual path. Connect a keyboard and display
+directly to the Pi, or SSH in over a wired ethernet connection, then:
 
 ```
-apt install firmware-brcm80211 pi-bluetooth wpasupplicant iw crda wireless-regdb
+sudo nmtui
 ```
 
-Next, we need to configure the wifi interface, open `/etc/network/interfaces` in your favorite editor and
-add the following
+Choose "Activate a connection" → pick your SSID → enter the password.
+NetworkManager creates and stores the profile automatically; it will
+auto-connect on every subsequent boot. To confirm it's working:
 
 ```
-allow-hotplug wlan0
-auto wlan0
-
-iface wlan0 inet dhcp
-        wpa-ssid "<replace with the name of your wifi>"
-        wpa-psk "<replace with the password for your wifi>"
+nmcli connection show --active
 ```
 
-Next, let's make sure it works, so issue `ifup wlan0` and after it completes, running `ifconfig wlan0` and it should show something similar to this
+You should see your WiFi connection listed.
+
+## Option B: Command-line via `nmcli`
+
+Non-interactive, scriptable:
 
 ```
-wlan0     Link encap:Ethernet  HWaddr de:ad:be:ef:11:11
-          inet addr:10.0.0.2  Bcast:10.0.0.255  Mask:255.255.255.0
-          inet6 addr: fe80::bc27:ffff:fe9c:aa6/64 Scope:Link
-          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
-          RX packets:108005 errors:0 dropped:0 overruns:0 frame:0
-          TX packets:77150 errors:0 dropped:0 overruns:0 carrier:0
-          collisions:0 txqueuelen:1000
-          RX bytes:129102030 (123.1 MiB)  TX bytes:7841326 (7.4 MiB)
+sudo nmcli device wifi connect "<your-ssid>" password "<your-password>"
 ```
 
-What we care about is that the line with `inet addr:` is present, it indicates network. At this point, try using SSH to connect to this IP just to be sure it works.
-If that pans out, reboot and make sure it still works, I've been biten by this before. Once you see that you can SSH into the RPi3 using the wifi address, it's time
-to disable the wired interface.
+NetworkManager creates the profile and activates it immediately. For
+networks with non-ASCII or special characters in the SSID or password,
+wrap each value in single quotes to avoid shell-quoting confusion.
 
-Open `/etc/network/interfaces` and add a hash `#` in front of the two lines with `eth0`, it should look like this
+## Regulatory domain (country code)
+
+**Important:** without a configured regulatory domain, the kernel's
+`cfg80211` module will refuse to transmit on any WiFi channel, and
+`nmcli device wifi list` returns empty. Bookworm Lite ships without
+a default country set.
+
+Set your country via `raspi-config` (interactive):
 
 ```
-#auto eth0
-#iface eth0 inet dhcp
+sudo raspi-config
 ```
 
-Save it and then start `raspi-config`.
+Navigate to **Localisation Options** → **WLAN Country** → select your
+country code (e.g., `US`, `GB`, `DE`, `JP`). Exit; the change takes
+effect immediately, though a reboot is the safest way to confirm.
 
-Here you need to go to option 3, boot options and choose option 2, wait for network. It should be set to no.
+**Non-interactive equivalent:**
 
-Exit the config tool and then reboot, now your RPi3 will boot directly to WiFi and WiFi only. If you don't do it this way, the RPi3 will wait forever for a wired connection.
+```
+sudo raspi-config nonint do_wifi_country US
+```
+
+Replace `US` with your ISO 3166-1 alpha-2 code.
+
+## Disabling ethernet once WiFi is working
+
+If you configured WiFi over an initial wired connection and now want
+the Pi to boot headless on WiFi only, you do **not** need to disable
+the ethernet interface — NetworkManager handles both concurrently
+without conflict. The old `raspi-config` "wait for network" workaround
+described in MANUAL.md is not needed on Bookworm; systemd's default
+network-online target timeout is sensible. Just unplug the ethernet
+cable when you're done, and the Pi will continue to work on WiFi.
 
 # faq
 
 ## I want it to auto-update
 
-Easy, just schedule a cronjob to run `update.sh`. It will use git to update (if there are changes) as well as restart the service if it has updated. Ideally you run this once a week.
+Schedule a cronjob to run `update.sh`. It uses git to pull changes (if
+any) and restarts the service when it updates. The pre-built image
+from the releases page already schedules this at 3:15 AM daily via
+`/etc/crontab`. For a manual install, add the line yourself:
+
+```
+echo "15 3    * * *   root    /root/photoframe/update.sh" | \
+    sudo tee -a /etc/crontab
+```
+
+## How do I change the SSH password after install?
+
+Log in as the user you created (or the default `photoframe` user on
+the pre-built image) and run:
+
+```
+passwd
+```
+
+Then enter the old password and the new one twice. Do this **on first
+login** if you're using the pre-built image with default credentials.
+
+## My WiFi isn't connecting even though the credentials are right
+
+Three likely causes, in order of probability:
+
+1. **Regulatory domain not set.** Check with `sudo iw reg get`. If it
+   shows `country 00: DFS-UNSET`, run `sudo raspi-config nonint do_wifi_country US`
+   (or your country code) and reboot.
+2. **5 GHz network on a Pi Zero W.** The Pi Zero W and Zero 2 W only
+   support 2.4 GHz. If your router broadcasts separate 2.4 GHz and
+   5 GHz SSIDs, connect to the 2.4 GHz one. If it broadcasts a single
+   dual-band SSID, the Pi should negotiate 2.4 GHz automatically.
+3. **Wrong password.** Obvious but common. NetworkManager's failure
+   mode for a bad password is a `No secrets` error in `journalctl -u
+   NetworkManager -b 0`.
+
+## How does the pre-built image compare to this manual install?
+
+The pre-built image from the releases page is produced by the
+[`dev-brewery/pi-gen`](https://github.com/dev-brewery/pi-gen) fork on
+branch `bookworm-photoframe`. It does everything this guide does, plus:
+
+- Bakes in the `photoframe` / `photoframe` default user (change
+  immediately via `passwd` on first login)
+- Ships with `WPA_COUNTRY=US` as the default regulatory domain
+- Provides a `wifi-config.txt` file on the boot partition you can edit
+  on Windows before first boot for headless WiFi setup
+- Skips the stage3/4/5 desktop builds that would conflict with
+  photoframe's framebuffer takeover
+
+If you're producing an image for distribution to non-technical users,
+use the pi-gen fork instead of the manual install. See
+[`HISTORY.md`](https://github.com/dev-brewery/pi-gen/blob/bookworm-photoframe/HISTORY.md)
+in the pi-gen fork for the full story of why each of those defaults
+was chosen.
+
+## How do I test and develop on a desktop?
+
+Start `frame.py` with `--emulate` to run without an RPi. The emulator
+mode is useful for iterating on the web UI and photo-service code
+without needing to reflash a card every time.

--- a/README.md
+++ b/README.md
@@ -54,15 +54,63 @@ The installer handles all dependencies, service setup, and auto-update configura
 
 Default credentials: `photoframe` / `password` (change via `http-auth.json` in `/root/photoframe_config/`)
 
-### Option 2: SD card image
+### Option 2: SD card image (recommended for first-time users)
 
-Download from the [releases page](https://github.com/dev-brewery/photoframe/releases), flash to SD card with [Rufus](https://rufus.ie/), [Balena Etcher](https://etcher.balena.io/), or `dd`.
+Pre-built Raspberry Pi OS Lite images with photoframe preinstalled are attached to releases on the [photoframe releases page](https://github.com/dev-brewery/photoframe/releases). Flash, edit two files on the boot partition, boot, done. The image is built by the [`dev-brewery/pi-gen`](https://github.com/dev-brewery/pi-gen) fork (branch `bookworm-photoframe`) — see its [`HISTORY.md`](https://github.com/dev-brewery/pi-gen/blob/bookworm-photoframe/HISTORY.md) for how the image is produced if you want to rebuild from source.
 
-1. Flash image to SD card
-2. Edit `wifi-config.txt` on the `boot` partition with your WiFi credentials
-3. Boot the Pi and follow the on-screen instructions
+**Step 1 — flash the image.** Download the `.img.zip` from the releases page and flash with [Raspberry Pi Imager](https://www.raspberrypi.com/software/) (recommended), [Balena Etcher](https://etcher.balena.io/), [Rufus](https://rufus.ie/) in DD mode, or `dd` on Linux/Mac. In Raspberry Pi Imager, choose **"Use custom"** and point at the `.zip`.
 
-### Option 3: Migrate from mrworf/photoframe
+**Do not use Imager's gear icon / advanced settings** — those are greyed out for custom images, and the image already has its own mechanisms for every setting Imager would configure. Just flash it.
+
+**Step 2 — configure WiFi.** After Imager finishes, the SD card's `bootfs` partition is visible in Windows Explorer (or as `/Volumes/bootfs` on macOS, or auto-mounted on Linux). Open **`wifi-config.txt`** in a text editor that preserves Unix line endings (Notepad++, VS Code, `nano`, or `vim` — **not** regular Windows Notepad, which mangles line endings). Fill in your network:
+
+```ini
+[wifi]
+SSID=YourNetworkName
+PSK=YourPassword
+COUNTRY=US
+```
+
+Set `COUNTRY` to your ISO 3166-1 alpha-2 code (`GB`, `DE`, `CA`, `JP`, ...) if you're outside the US. Save the file. On first boot, the Pi reads this file, connects to your WiFi, and renames the file to `wifi-config.txt.applied` so you know it worked. If something goes wrong, a `wifi-config.txt.error` file appears with the reason.
+
+**Step 3 (optional) — force a custom display resolution.** Most HDMI monitors are auto-detected via EDID and need no configuration. If you're driving an atypical panel — e.g., an HDMI-to-LVDS adapter board feeding an old laptop LCD — edit **`cmdline.txt`** on the same `bootfs` partition and append the video mode to the single existing line (with a leading space, no newlines):
+
+```
+ video=HDMI-A-1:1366x768MR@60D
+```
+
+Replace `1366x768` with your panel's native resolution. Flag meanings: `M` = CVT timings, `R` = reduced blanking, `@60` = refresh rate, `D` = force DVI output and treat the port as connected even without HPD (needed for most HDMI-to-LVDS adapter boards, which don't assert HPD). On Bookworm's KMS driver, the legacy `hdmi_group` / `hdmi_mode` / `hdmi_cvt` options in `config.txt` are silently ignored — `cmdline.txt` is the only file that works.
+
+**Step 4 — eject and boot.** Safely eject the SD card from your computer, insert it into the Pi, and power on. Within 30 seconds the photoframe service starts, WiFi associates, and the frame is reachable on your network at `http://<pi-ip>:7777`.
+
+**Step 5 — SSH in and change the password.** The image ships with a default account so you can manage the Pi without any setup:
+
+- **Username:** `photoframe`
+- **Password:** `photoframe`
+
+From any computer on the same network:
+
+```bash
+ssh photoframe@<pi-ip>
+passwd    # change the password immediately on first login
+```
+
+If you'd rather use a different username, create one and remove the default after logging in:
+
+```bash
+sudo adduser yourname
+sudo usermod -aG sudo yourname
+# log out, log back in as yourname, then:
+sudo deluser --remove-home photoframe
+```
+
+The default web UI credentials (separate from SSH) are `photoframe` / `password` — change them via `http-auth.json` in `/root/photoframe_config/` or through the web UI.
+
+### Option 3: Manual install
+
+See [MANUAL.md](MANUAL.md) for a step-by-step walkthrough that mirrors what `install.sh` does, for users who want to understand every step or reproduce it on a system where the scripted path doesn't fit.
+
+### Option 4: Migrate from mrworf/photoframe
 
 If you're running the original mrworf version, see [MIGRATION.md](MIGRATION.md) for step-by-step instructions to switch to this fork.
 
@@ -117,14 +165,81 @@ Photoframe listens on GPIO 26 (configurable) for power control. Connect a moment
 
 ### How do I get SSH access?
 
-Place a file called `ssh` on the boot partition. Login with the default Raspberry Pi OS credentials. Avoid modifying files in `/root/photoframe/` directly, as this will prevent automatic updates via `update.sh`.
+It depends on which install path you used.
+
+**If you flashed the SD card image (Option 2):** SSH is enabled out of the box and the image ships with a default account so you can get in from any OS (Windows, macOS, Linux) without extra setup:
+
+- **Username:** `photoframe`
+- **Password:** `photoframe`
+
+```bash
+ssh photoframe@<your-pi-ip>
+```
+
+**Change the password immediately on first login:**
+
+```bash
+passwd
+```
+
+If you'd rather use a different username, create one and remove the default after logging in:
+
+```bash
+sudo adduser yourname
+sudo usermod -aG sudo yourname
+# log out, log back in as yourname, then:
+sudo deluser --remove-home photoframe
+```
+
+**If you installed via `install.sh` on a fresh Raspberry Pi OS (Option 1):** SSH and user accounts are whatever you configured when flashing Raspberry Pi OS itself. If you used Raspberry Pi Imager's advanced settings (gear icon) to set a username, password, and enable SSH, you're already set — just `ssh <youruser>@<your-pi-ip>`. Otherwise, enable SSH on the Pi with `sudo raspi-config` (Interfaces → SSH), or place an empty file named `ssh` on the boot partition before first boot.
+
+Avoid modifying files in `/root/photoframe/` directly, as this will prevent automatic updates via `update.sh`.
+
+### My display shows nothing or the wrong resolution
+
+Most HDMI monitors are auto-detected via EDID. If you're driving an atypical panel (e.g. an HDMI-to-LVDS adapter board feeding a laptop LCD) that doesn't report EDID, you'll need to force the mode manually. The right place to do this depends on which Raspberry Pi OS release you're on, because Bookworm and Bullseye use different display stacks.
+
+**On Bookworm (KMS driver):** custom modes go on the kernel command line, not in `config.txt`. Legacy `hdmi_group` / `hdmi_mode` / `hdmi_cvt` / `hdmi_force_hotplug` settings in `config.txt` are silently ignored under the `vc4-kms-v3d` driver.
+
+```bash
+sudo nano /boot/firmware/cmdline.txt
+```
+
+`cmdline.txt` is a single line — do not add newlines. Append (with a leading space):
+
+```
+video=HDMI-A-1:1366x768MR@60D
+```
+
+Replace `1366x768` with your panel's native resolution. Flag meanings: `M` = CVT timings, `R` = reduced blanking, `@60` = refresh rate, `D` = force DVI-style output and treat the port as connected even without HPD (required because most adapter boards don't assert HPD). Reboot to apply.
+
+**On Bullseye (legacy firmware display path):** the traditional `config.txt` knobs still work.
+
+```bash
+sudo nano /boot/config.txt
+```
+
+Add:
+
+```
+hdmi_force_hotplug=1
+hdmi_group=2
+hdmi_mode=87
+hdmi_cvt=1366 768 60 3 0 0 1
+```
+
+Replace `1366 768` with your panel's native resolution. `hdmi_mode=87` is the "use custom CVT" slot that activates `hdmi_cvt`; `hdmi_force_hotplug=1` is required because most driver boards don't assert HPD. Reboot to apply.
 
 ### Are there logs?
 
-Logs are in `/var/log/syslog` (search for `frame` or `photoframe` entries). For verbose debug output:
+On Bookworm: `journalctl -u frame.service -f` (or the in-UI log viewer under **Settings**, which falls back to `journalctl` automatically when `/var/log/syslog` is absent — Bookworm Lite doesn't ship `rsyslog`).
+
+On older releases that still have `rsyslog`: `/var/log/syslog` works too (search for `frame` or `photoframe`).
+
+For verbose debug output:
 
 ```bash
-service frame stop
+sudo systemctl stop frame.service
 /root/photoframe/frame.py --debug
 ```
 
@@ -134,7 +249,7 @@ Run `frame.py` with `--emulate` to run without RPi hardware.
 
 ### How do I build my own SD card image?
 
-Check out the `photoframe` branch on https://github.com/dev-brewery/pi-gen for the pi-gen configuration used to build release images.
+Check out the `bookworm-photoframe` branch on https://github.com/dev-brewery/pi-gen for the pi-gen configuration used to build release images. The [`build-image.yml`](.github/workflows/build-image.yml) workflow in this repo runs that same build in CI and attaches the resulting `.zip` to the release for the tag being built.
 
 ### USB sticks not recognized?
 

--- a/update.sh
+++ b/update.sh
@@ -72,10 +72,14 @@ if [ "$1" = "post" ]; then
 
 	# Make sure all old files are moved into the new config folder
 	mkdir /root/photoframe_config >/dev/null 2>/dev/null
-	FILES="oauth.json settings.json http_auth.json colortemp.sh"
+	FILES="oauth.json settings.json http-auth.json colortemp.sh"
 	for FILE in ${FILES}; do
 		mv /root/${FILE} /root/photoframe_config/ >/dev/null 2>/dev/null
 	done
+	# Legacy underscore name: very old upstream installs used
+	# /root/http_auth.json. The runtime now reads http-auth.json
+	# (modules/sysconfig.py:146), so migrate the location AND the name.
+	mv /root/http_auth.json /root/photoframe_config/http-auth.json >/dev/null 2>/dev/null
 
 	# We also have added more dependencies, so add more software
 	apt-get update


### PR DESCRIPTION
## Summary

The in-repo `README.md` and `MANUAL.md` on `dev` still describe mrworf's pre-Bookworm / Python 2 reality — minibian, `/etc/network/interfaces`, Google Photos as the primary photo source, etc. This PR replaces them with drafts that reflect what v3.x actually ships (Immich + USB as primary sources, Bookworm Lite, Python 3, pre-built SD card image with `photoframe`/`photoframe` SSH and `photoframe`/`password` web UI credentials).

## Provenance

Drafts lifted from the `rollout-plan` branch (which has sat unmerged since 2026-04-11 carrying the original rewrites) with targeted patches against review feedback from an independent reviewer:

**README patches on top of rollout-plan:**
- Pi-gen branch name fixed in the "build your own SD card image" FAQ: `photoframe` → `bookworm-photoframe`, with a pointer to `.github/workflows/build-image.yml` (which runs the same build in CI).
- Logs FAQ now leads with `journalctl -u frame.service -f` — Bookworm Lite doesn't ship `rsyslog`, so `/var/log/syslog` is absent by default. Demoted to a fallback.
- Added **Option 3: Manual install** linking `MANUAL.md`; the rollout-plan README didn't reference it.
- `video=HDMI-A-1:…MR@60D` unified across all three occurrences. Covers both the reduced-blanking-LCD and the no-HPD-adapter failure modes — the two scenarios the `cmdline.txt` mode-forcing example is meant to fix.

**MANUAL patches on top of rollout-plan's `MANUALv3.md`:**
- Dropped the "original MANUAL.md remains in the repository" preamble; no longer true (this PR collapses to a single `MANUAL.md`, and the pre-Bookworm content is reachable via `git log -- MANUAL.md`).
- Same `video=…MR@60D` unification.

## Review-caught regressions this PR fixes (vs my initial draft)

I wrote first-pass drafts of both files before finding the rollout-plan branch. An independent reviewer caught these functional defects in my drafts:

- **`pip3 install -r requirements.txt` without `--break-system-packages`.** This flat-out fails on Bookworm under PEP 668 enforcement. The adopted text uses `--break-system-packages` with rationale.
- **Missing `python3-smbus`** from the apt install list. Without it, the TCS34725 color-temperature sensor silently can't be opened.
- **Missing `rng-tools-debian`.** Diverges from pi-gen's package list — hand-built install wouldn't match the shipped image.
- **`wifi-config.txt` bare key-value format.** Confirmed against the parser in `dev-brewery/pi-gen@bookworm-photoframe/stage2/04-photoframe/files/photoframe-wifi-setup.sh`: the `[wifi]` INI section header is REQUIRED.

## Test plan

- [ ] Render the README and MANUAL on GitHub, check all in-repo links resolve at this branch (MIGRATION.md, README-Immich.md, GOOGLE_PHOTOS.md, install.sh, .github/workflows/build-image.yml).
- [ ] Spot-check `MR@60D` video= line against a Pi with an atypical panel if you have one to hand — otherwise leave as-is (reduced-blanking + DVI-force is the superset that covers both failure modes).
- [ ] Merge.

## Does not cover

The `v3.0.0-rc1` release tag still has the stale README / MANUAL in its tree, because this PR targets `dev`. Fixing the rc1 tag tree is a separate question (move the tag forward? re-cut as rc2? accept and fix-forward only?) — raising it in conversation, not in this PR.