### PR TITLE
fix: reconcile http-auth.json filename convention in update.sh

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -80,6 +80,9 @@ if [ "$1" = "post" ]; then
 	# /root/http_auth.json. The runtime now reads http-auth.json
 	# (modules/sysconfig.py:146), so migrate the location AND the name.
 	mv /root/http_auth.json /root/photoframe_config/http-auth.json >/dev/null 2>/dev/null
+	# Also handle the case where a prior update.sh already relocated the
+	# underscore file into photoframe_config/ without renaming it.
+	mv /root/photoframe_config/http_auth.json /root/photoframe_config/http-auth.json >/dev/null 2>/dev/null
 
 	# We also have added more dependencies, so add more software
 	apt-get update


### PR DESCRIPTION
## Summary

PR #39 review blocker — `update.sh:75` migrates `/root/http_auth.json` (underscore), but the runtime in `modules/sysconfig.py:146` reads `http-auth.json` (hyphen). The entire rest of the codebase, the pi-gen image, the `.gitignore`, and the docs all use hyphen; only this one line diverges.

Upstream-inherited: the line traces back to mrworf commit `60e4e4f "Internal display support"` and has never been reconciled.

## Fix

- Change the main `FILES` list to `http-auth.json`.
- Add an explicit rename for any legacy `/root/http_auth.json` so users with very old installs still get their auth file migrated into the new location AND the new name, not left stranded under an old name the runtime no longer reads.

## Net effect per install path

| user state | before this PR | after this PR |
|---|---|---|
| `/root/http-auth.json` (modern install somehow, rare) | not moved (list had wrong name) | moved to `/root/photoframe_config/http-auth.json` |
| `/root/http_auth.json` (legacy install) | moved to `/root/photoframe_config/http_auth.json` — **runtime ignores it**, auth breaks | moved to `/root/photoframe_config/http-auth.json` — runtime reads it, auth works |
| `/root/photoframe_config/http-auth.json` already present | no-op | no-op |

## Test plan

- [ ] Merge this PR.
- [ ] Rebase/remerge PR #39 on top; that one's docs now match the code.

## Out of scope

Not touching `clean_3x` / `v3.0.0-rc1`. Rc1 shipped with the underscore bug; any rc1 user hit by it can either edit one line in their update.sh or re-flash the rc2 image once cut.