### PR TITLE
ci: require pi_gen_ref on dispatch, auto-derive on tag push

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -11,10 +11,9 @@ on:
         required: true
         type: string
       pi_gen_ref:
-        description: 'dev-brewery/pi-gen ref to build with'
-        required: false
+        description: 'dev-brewery/pi-gen ref (required — e.g. v3.0.0-rc1 for a reproducible build, or a branch/SHA for testing)'
+        required: true
         type: string
-        default: bookworm-photoframe
 
 permissions:
   contents: write
@@ -31,7 +30,11 @@ jobs:
     timeout-minutes: 180
     env:
       PHOTOFRAME_TAG: ${{ github.event.inputs.tag || github.ref_name }}
-      PI_GEN_REF: ${{ github.event.inputs.pi_gen_ref || 'bookworm-photoframe' }}
+      # On tag push, pi-gen is checked out at the matching tag (pi-gen
+      # tag names mirror photoframe tag names — see dev-brewery/pi-gen's
+      # RELEASE.md). On workflow_dispatch, the user supplies pi_gen_ref
+      # explicitly; no silent fallback to a branch.
+      PI_GEN_REF: ${{ github.event.inputs.pi_gen_ref || github.ref_name }}
 
     steps:
       - name: Free disk space on runner


### PR DESCRIPTION
## Summary

Phase 3 of the pi-gen formal-release-track plan. Pairs with dev-brewery/pi-gen PR #2 (pi-gen side) and the already-pushed `v3.0.0-rc1` pi-gen tag.

Two changes to `.github/workflows/build-image.yml`:

1. **`pi_gen_ref` is required on `workflow_dispatch`**. Removes the `default: bookworm-photoframe` fallback so ad-hoc manual builds can't silently float on a branch.
2. **`PI_GEN_REF` expression changed**: `\${{ inputs.pi_gen_ref || github.ref_name }}`. On tag push (`v3.0.0-rc2`, etc.), pi-gen is checked out at the matching tag — no workflow edits per release.

## Behaviour by trigger

| Trigger | `inputs.pi_gen_ref` | `PI_GEN_REF` resolves to |
|---|---|---|
| `push: tags: v*` (e.g. `v3.0.0-rc2`) | empty | `v3.0.0-rc2` (photoframe tag name → pi-gen tag of same name) |
| `workflow_dispatch` with `pi_gen_ref=v3.0.0-rc1` | `v3.0.0-rc1` | `v3.0.0-rc1` |
| `workflow_dispatch` with `pi_gen_ref=bookworm-photoframe` | `bookworm-photoframe` | `bookworm-photoframe` (branch, for testing unreleased pi-gen work) |
| `workflow_dispatch` with no input | ❌ form rejects — required=true | — |

## Dependency

This PR depends on dev-brewery/pi-gen PR #2 landing first so that the pi-gen release tags actually exist when tag-push resolves `github.ref_name`. The `v3.0.0-rc1` pi-gen tag is already pushed independently, so a retroactive dispatch against rc1 would already work.

**Merge order:** pi-gen#2 → this PR.

## Test plan

- [ ] Merge pi-gen #2.
- [ ] Merge this PR to `dev`.
- [ ] Dispatch the workflow manually with `tag=v3.0.0-rc1` and `pi_gen_ref=v3.0.0-rc1`. Confirm pi-gen is checked out at the tag and the build succeeds.
- [ ] (Later, when rc2 is cut) push the paired pi-gen `v3.0.0-rc2` tag, then the photoframe `v3.0.0-rc2` tag — workflow should fire and build with zero manual input.

## Out of scope

- Not touching the `v3.0.0-rc1` release or its attached asset.
- Not modifying master (this lives on dev until the normal dev-merge cycle).