### PR TITLE
docs: add RELEASE.md mirroring pi-gen's release cadence

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -125,9 +125,11 @@ jobs:
       # pi-gen's default DEPLOY_COMPRESSION=zip emits
       # image_YYYY-MM-DD-<IMG_NAME>-lite.zip (the build date is
       # prepended automatically). Pi Imager consumes .zip natively —
-      # the archive holds a single YYYY-MM-DD-<IMG_NAME>-lite.img entry
-      # (pi-gen's IMG_FILENAME = IMG_DATE + IMG_NAME, used for both the
-      # outer zip and the inner .img) — so ship what pi-gen produces.
+      # the archive holds a single YYYY-MM-DD-<IMG_NAME>-lite.img entry.
+      # Pi-gen uses two distinct variables that both start with the
+      # date: ARCHIVE_FILENAME='image_'+IMG_DATE+IMG_NAME for the outer
+      # zip and IMG_FILENAME=IMG_DATE+IMG_NAME for the inner .img.
+      # So ship what pi-gen produces.
       - name: Upload workflow artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -125,8 +125,9 @@ jobs:
       # pi-gen's default DEPLOY_COMPRESSION=zip emits
       # image_YYYY-MM-DD-<IMG_NAME>-lite.zip (the build date is
       # prepended automatically). Pi Imager consumes .zip natively —
-      # the archive holds a single <IMG_NAME>-lite.img entry — so ship
-      # what pi-gen produces.
+      # the archive holds a single YYYY-MM-DD-<IMG_NAME>-lite.img entry
+      # (pi-gen's IMG_FILENAME = IMG_DATE + IMG_NAME, used for both the
+      # outer zip and the inner .img) — so ship what pi-gen produces.
       - name: Upload workflow artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -42,7 +42,7 @@ jobs:
       # `required: true` on workflow_dispatch inputs rejects omission at
       # the UI/CLI layer but accepts empty strings. Without this guard,
       # `gh workflow run ... -f pi_gen_ref=""` falls through to the
-      # `|| github.ref_name` fallback on line 37 and silently builds
+      # `|| github.ref_name` fallback on line 39 and silently builds
       # against whatever branch the dispatch was triggered from.
       - name: Validate dispatch inputs
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -122,8 +122,11 @@ jobs:
         working-directory: pi-gen/deploy
         run: ls -lah
 
-      # pi-gen's default DEPLOY_COMPRESSION=zip emits image_<IMG_NAME>-lite.zip.
-      # Pi Imager consumes .zip natively, so ship what pi-gen produces.
+      # pi-gen's default DEPLOY_COMPRESSION=zip emits
+      # image_YYYY-MM-DD-<IMG_NAME>-lite.zip (the build date is
+      # prepended automatically). Pi Imager consumes .zip natively —
+      # the archive holds a single <IMG_NAME>-lite.img entry — so ship
+      # what pi-gen produces.
       - name: Upload workflow artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -47,6 +47,10 @@ jobs:
       - name: Validate dispatch inputs
         if: github.event_name == 'workflow_dispatch'
         run: |
+          if [ -z "${{ inputs.tag }}" ]; then
+            echo "::error::tag is required on workflow_dispatch — no default, no empty-string fallback"
+            exit 1
+          fi
           if [ -z "${{ inputs.pi_gen_ref }}" ]; then
             echo "::error::pi_gen_ref is required on workflow_dispatch — no default, no empty-string fallback"
             exit 1

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -3,7 +3,9 @@ name: Build Photoframe LITE image
 on:
   push:
     tags:
-      - 'v*'
+      # Semver-shaped release tags only. Prevents ad-hoc v-prefixed tags
+      # (vtest, vexperiment) from firing a ~5-minute release build.
+      - 'v[0-9]*.[0-9]*.[0-9]*'
   workflow_dispatch:
     inputs:
       tag:
@@ -37,6 +39,32 @@ jobs:
       PI_GEN_REF: ${{ github.event.inputs.pi_gen_ref || github.ref_name }}
 
     steps:
+      # `required: true` on workflow_dispatch inputs rejects omission at
+      # the UI/CLI layer but accepts empty strings. Without this guard,
+      # `gh workflow run ... -f pi_gen_ref=""` falls through to the
+      # `|| github.ref_name` fallback on line 37 and silently builds
+      # against whatever branch the dispatch was triggered from.
+      - name: Validate dispatch inputs
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if [ -z "${{ inputs.pi_gen_ref }}" ]; then
+            echo "::error::pi_gen_ref is required on workflow_dispatch — no default, no empty-string fallback"
+            exit 1
+          fi
+
+      # Fail fast if the paired pi-gen ref is missing. Without this,
+      # the error surfaces ~60s later at the pi-gen checkout step,
+      # after QEMU setup and photoframe checkout have run. `gh api
+      # commits/<ref>` accepts tags, branches, and SHAs.
+      - name: Verify pi-gen ref exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if ! gh api "repos/dev-brewery/pi-gen/commits/${PI_GEN_REF}" --silent 2>/dev/null; then
+            echo "::error::dev-brewery/pi-gen has no ref '${PI_GEN_REF}'. On tag push the pi-gen tag name mirrors the photoframe tag — cut the paired pi-gen tag first (see pi-gen's RELEASE.md)."
+            exit 1
+          fi
+
       - name: Free disk space on runner
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Default credentials: `photoframe` / `password` (change via `http-auth.json` in `
 
 Pre-built Raspberry Pi OS Lite images with photoframe preinstalled are attached to releases on the [photoframe releases page](https://github.com/dev-brewery/photoframe/releases). Flash, edit two files on the boot partition, boot, done. The image is built by the [`dev-brewery/pi-gen`](https://github.com/dev-brewery/pi-gen) fork (branch `bookworm-photoframe`) — see its [`HISTORY.md`](https://github.com/dev-brewery/pi-gen/blob/bookworm-photoframe/HISTORY.md) for how the image is produced if you want to rebuild from source.
 
-**Step 1 — flash the image.** Download the `.img.zip` from the releases page and flash with [Raspberry Pi Imager](https://www.raspberrypi.com/software/) (recommended), [Balena Etcher](https://etcher.balena.io/), [Rufus](https://rufus.ie/) in DD mode, or `dd` on Linux/Mac. In Raspberry Pi Imager, choose **"Use custom"** and point at the `.zip`.
+**Step 1 — flash the image.** Download the `image_*-lite.zip` asset from the releases page and flash with [Raspberry Pi Imager](https://www.raspberrypi.com/software/) (recommended), [Balena Etcher](https://etcher.balena.io/), [Rufus](https://rufus.ie/) in DD mode, or `dd` on Linux/Mac. In Raspberry Pi Imager, choose **"Use custom"** and point at the `.zip`.
 
 **Do not use Imager's gear icon / advanced settings** — those are greyed out for custom images, and the image already has its own mechanisms for every setting Imager would configure. Just flash it.
 

--- a/README.md
+++ b/README.md
@@ -251,6 +251,16 @@ Run `frame.py` with `--emulate` to run without RPi hardware.
 
 Check out the `bookworm-photoframe` branch on https://github.com/dev-brewery/pi-gen for the pi-gen configuration used to build release images. The [`build-image.yml`](.github/workflows/build-image.yml) workflow in this repo runs that same build in CI and attaches the resulting `.zip` to the release for the tag being built.
 
+Release builds fire automatically on `v*.*.*` tag push and resolve the pi-gen ref from the photoframe tag name (pi-gen tag names mirror photoframe tag names 1:1). To rebuild an image manually:
+
+```
+gh workflow run build-image.yml \
+  -f tag=v3.0.0-rc1 \
+  -f pi_gen_ref=v3.0.0-rc1
+```
+
+Both inputs are required — there is no default. For a byte-for-byte rebuild of a released image, pass the same tag name for both. For testing an unreleased photoframe branch against a specific pi-gen commit, pass a branch or SHA for `pi_gen_ref`.
+
 ### USB sticks not recognized?
 
 Install exFAT support: `sudo apt install exfat-fuse exfat-utils`

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Run `frame.py` with `--emulate` to run without RPi hardware.
 
 Check out the `bookworm-photoframe` branch on https://github.com/dev-brewery/pi-gen for the pi-gen configuration used to build release images. The [`build-image.yml`](.github/workflows/build-image.yml) workflow in this repo runs that same build in CI and attaches the resulting `.zip` to the release for the tag being built.
 
-Release builds fire automatically on `v*.*.*` tag push and resolve the pi-gen ref from the photoframe tag name (pi-gen tag names mirror photoframe tag names 1:1). To rebuild an image manually:
+Release builds fire automatically on `v[0-9]*.[0-9]*.[0-9]*` tag push and resolve the pi-gen ref from the photoframe tag name (pi-gen tag names mirror photoframe tag names 1:1). To rebuild an image manually:
 
 ```
 gh workflow run build-image.yml \

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,8 +14,9 @@ For each release `vX.Y.Z[-rcN]`:
 
 1. Land all in-scope work on `dev`.
 2. Cut the paired pi-gen tag first — follow pi-gen's RELEASE.md. That step also bumps `config.example`'s `PHOTOFRAME_BRANCH` to the new photoframe tag name, so a manual `git clone --branch <tag> pi-gen && ./build-docker.sh` reproduces this release's image without overrides. The bump and tag must happen in the same commit: a pi-gen tag whose `config.example` still names the previous release breaks reproducibility **and corrupts CI builds too** — pi-gen's `stage2/04-photoframe/01-run.sh` runs `git checkout ${PHOTOFRAME_BRANCH}` inside the rootfs even when CI passes `PHOTOFRAME_SRC`, so a stale `PHOTOFRAME_BRANCH` in `config.example` either fails the checkout or silently ships the wrong commit.
-3. Tag photoframe at the exact `dev` commit being released. Resolve the SHA first so the tag isn't at the mercy of whatever lands on `dev` between reading the docs and running the commands:
+3. Tag photoframe at the exact `dev` commit being released. Fetch first so the local `origin/dev` ref is fresh, then pin the SHA so the tag isn't at the mercy of whatever lands on `dev` between reading the docs and running the commands:
    ```bash
+   git fetch origin dev
    SHA=$(git rev-parse origin/dev)   # pin the release commit
    git tag -a vX.Y.Z -m 'release vX.Y.Z' "$SHA"
    git push origin vX.Y.Z

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,9 +14,10 @@ For each release `vX.Y.Z[-rcN]`:
 
 1. Land all in-scope work on `dev`.
 2. Cut the paired pi-gen tag first — follow pi-gen's RELEASE.md. That step also bumps `config.example`'s `PHOTOFRAME_BRANCH` to the new photoframe tag name, so a manual `git clone --branch <tag> pi-gen && ./build-docker.sh` reproduces this release's image without overrides. The bump and tag must happen in the same commit: a pi-gen tag whose `config.example` still names the previous release breaks reproducibility **and corrupts CI builds too** — pi-gen's `stage2/04-photoframe/01-run.sh` runs `git checkout ${PHOTOFRAME_BRANCH}` inside the rootfs even when CI passes `PHOTOFRAME_SRC`, so a stale `PHOTOFRAME_BRANCH` in `config.example` either fails the checkout or silently ships the wrong commit.
-3. Tag photoframe at the `dev` commit being released:
+3. Tag photoframe at the exact `dev` commit being released. Resolve the SHA first so the tag isn't at the mercy of whatever lands on `dev` between reading the docs and running the commands:
    ```bash
-   git tag -a vX.Y.Z -m 'release vX.Y.Z' dev
+   SHA=$(git rev-parse origin/dev)   # pin the release commit
+   git tag -a vX.Y.Z -m 'release vX.Y.Z' "$SHA"
    git push origin vX.Y.Z
    ```
 4. Tag push fires `build-image.yml`, which checks out pi-gen at the matching tag, builds the LITE image, and attaches it to the auto-created GitHub release.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -22,7 +22,7 @@ For each release `vX.Y.Z[-rcN]`:
    git push origin vX.Y.Z
    ```
 4. Tag push fires `build-image.yml`, which checks out pi-gen at the matching tag, builds the LITE image, and attaches it to the auto-created GitHub release.
-5. Verify the release page has the `image_photoframe-vX.Y.Z-lite.zip` artifact before announcing.
+5. Verify the release page has the `image_YYYY-MM-DD-photoframe-vX.Y.Z-lite.zip` artifact before announcing (pi-gen prepends the build date to `IMG_NAME`, so the filename includes the date the runner produced it).
 
 ## Manual dispatch
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,14 +6,14 @@ Every photoframe release is paired 1:1 with a [`dev-brewery/pi-gen`](https://git
 
 **Pi-gen tag first, photoframe tag second.**
 
-`.github/workflows/build-image.yml` resolves `PI_GEN_REF` from `github.ref_name` on `push: tags: v*`. If the matching pi-gen tag is missing when the photoframe tag is pushed, the workflow fails fast at the pi-gen checkout step. That's the forcing function — don't route around it.
+`.github/workflows/build-image.yml` resolves `PI_GEN_REF` from `github.ref_name` on `push: tags: v[0-9]*.[0-9]*.[0-9]*`. If the matching pi-gen tag is missing when the photoframe tag is pushed, the workflow fails fast at the `Verify pi-gen ref exists` pre-flight step — before QEMU setup or any checkout runs. That's the forcing function — don't route around it.
 
 ## Per-release steps (photoframe side)
 
 For each release `vX.Y.Z[-rcN]`:
 
 1. Land all in-scope work on `dev`.
-2. Cut the paired pi-gen tag first — follow pi-gen's RELEASE.md. That step also bumps `config.example`'s `PHOTOFRAME_BRANCH` to the new photoframe tag name, so a manual `git clone --branch <tag> pi-gen && ./build-docker.sh` reproduces this release's image without overrides. The bump and tag must happen in the same commit: a pi-gen tag whose `config.example` still names the previous release breaks reproducibility.
+2. Cut the paired pi-gen tag first — follow pi-gen's RELEASE.md. That step also bumps `config.example`'s `PHOTOFRAME_BRANCH` to the new photoframe tag name, so a manual `git clone --branch <tag> pi-gen && ./build-docker.sh` reproduces this release's image without overrides. The bump and tag must happen in the same commit: a pi-gen tag whose `config.example` still names the previous release breaks reproducibility **and corrupts CI builds too** — pi-gen's `stage2/04-photoframe/01-run.sh` runs `git checkout ${PHOTOFRAME_BRANCH}` inside the rootfs even when CI passes `PHOTOFRAME_SRC`, so a stale `PHOTOFRAME_BRANCH` in `config.example` either fails the checkout or silently ships the wrong commit.
 3. Tag photoframe at the `dev` commit being released:
    ```bash
    git tag -a vX.Y.Z -m 'release vX.Y.Z' dev

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,31 @@
+# Release process
+
+Every photoframe release is paired 1:1 with a [`dev-brewery/pi-gen`](https://github.com/dev-brewery/pi-gen) tag of the **same name**. The pi-gen tag pins the exact pi-gen commit used to build the image attached to the photoframe release. See [pi-gen's RELEASE.md](https://github.com/dev-brewery/pi-gen/blob/bookworm-photoframe/RELEASE.md) for the pi-gen-side steps.
+
+## Ordering
+
+**Pi-gen tag first, photoframe tag second.**
+
+`.github/workflows/build-image.yml` resolves `PI_GEN_REF` from `github.ref_name` on `push: tags: v*`. If the matching pi-gen tag is missing when the photoframe tag is pushed, the workflow fails fast at the pi-gen checkout step. That's the forcing function — don't route around it.
+
+## Per-release steps (photoframe side)
+
+For each release `vX.Y.Z[-rcN]`:
+
+1. Land all in-scope work on `dev`.
+2. Cut the paired pi-gen tag first — follow pi-gen's RELEASE.md. That step also bumps `config.example`'s `PHOTOFRAME_BRANCH` to the new photoframe tag name, so a manual `git clone --branch <tag> pi-gen && ./build-docker.sh` reproduces this release's image without overrides. The bump and tag must happen in the same commit: a pi-gen tag whose `config.example` still names the previous release breaks reproducibility.
+3. Tag photoframe at the `dev` commit being released:
+   ```bash
+   git tag -a vX.Y.Z -m 'release vX.Y.Z' dev
+   git push origin vX.Y.Z
+   ```
+4. Tag push fires `build-image.yml`, which checks out pi-gen at the matching tag, builds the LITE image, and attaches it to the auto-created GitHub release.
+5. Verify the release page has the `image_photoframe-vX.Y.Z-lite.zip` artifact before announcing.
+
+## Manual dispatch
+
+```
+gh workflow run build-image.yml -f tag=<photoframe-tag> -f pi_gen_ref=<pi-gen-ref>
+```
+
+Both inputs are required; there is no default. For a byte-for-byte rebuild of a released image, pass the same tag name for both. For testing an unreleased photoframe branch against a specific pi-gen ref, pass a branch or SHA for `pi_gen_ref`.


### PR DESCRIPTION
## Summary
- PR #48 added the CI-side enforcement of the paired-tag policy (`pi_gen_ref` required on dispatch, `github.ref_name` on tag push) but shipped no photoframe-side release doc. Pi-gen has `RELEASE.md`; photoframe didn't.
- Adds `RELEASE.md` covering: the pi-gen-first ordering as a forcing function, the per-release steps (including that pi-gen's `config.example` bump and tag must happen in lockstep), and the both-inputs-required dispatch contract.

## Test plan
- [ ] Confirm links to pi-gen's RELEASE.md resolve.
- [ ] Confirm the per-release steps match what a releaser would actually run for rc2.