### PR TITLE
feat(control): add HTTP endpoints for screen on/off

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -303,3 +303,20 @@ was chosen.
 Start `frame.py` with `--emulate` to run without an RPi. The emulator
 mode is useful for iterating on the web UI and photo-service code
 without needing to reflash a card every time.
+
+## HTTP API for display control
+
+The display can be turned on and off via HTTP, useful for home
+automation integration (Home Assistant, Domoticz, etc.):
+
+```bash
+# Turn screen off
+curl -u photoframe:password http://<pi-ip>:7777/control/screenoff
+
+# Turn screen on
+curl -u photoframe:password http://<pi-ip>:7777/control/screenon
+```
+
+These endpoints respect the HTTP authentication configured in
+`/root/photoframe_config/http-auth.json`. Both return JSON:
+`{"screen": "on", "success": true}` or `{"screen": "off", "success": true}`.

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -320,3 +320,9 @@ curl -u photoframe:password http://<pi-ip>:7777/control/screenon
 These endpoints respect the HTTP authentication configured in
 `/root/photoframe_config/http-auth.json`. Both return JSON:
 `{"screen": "on", "success": true}` or `{"screen": "off", "success": true}`.
+
+**Note:** This is API groundwork for a future persistent manual override
+feature. Currently, schedule and ambient light sensor rules continue to
+run and may revert the display state on the next evaluation cycle (up to
+60 seconds). A future release will add the ability to hold a manual
+override until explicitly cleared.

--- a/frame.py
+++ b/frame.py
@@ -150,7 +150,7 @@ class Photoframe:
     self._loadRoute('configupload', 'RouteConfigUpload', self.serviceMgr, self.slideshow)
     self._loadRoute('immichconfigupload', 'RouteImmichConfigUpload', self.serviceMgr, self.slideshow)
     self._loadRoute('service', 'RouteService', self.serviceMgr, self.slideshow)
-    self._loadRoute('control', 'RouteControl', self.slideshow)
+    self._loadRoute('control', 'RouteControl', self.slideshow, self.timekeeperMgr)
     self._loadRoute('events', 'RouteEvents', self.eventMgr)
     self._loadRoute('debug', 'RouteDebug', self.displayMgr)
 

--- a/modules/timekeeper.py
+++ b/modules/timekeeper.py
@@ -112,6 +112,18 @@ class timekeeper(Thread):
 			logging.debug(f'Notifying {repr(listener)} of power change to {hasPower}')
 			listener(hasPower)
 
+	def setManualPower(self, enable):
+		"""Set display power manually, bypassing schedule/sensor logic.
+
+		Updates standby state so evaluatePower() won't immediately undo the change.
+		The next schedule/sensor trigger will still apply if conditions are met.
+		"""
+		new_standby = not enable
+		if self.standby != new_standby:
+			self.standby = new_standby
+			logging.info(f'Manual power control: display {"on" if enable else "off"}')
+			self.notifyListeners(enable)
+
 	def run(self):
 		self.scheduleOff = False
 		while True:

--- a/routes/control.py
+++ b/routes/control.py
@@ -19,12 +19,20 @@
 from .baseroute import BaseRoute
 
 class RouteControl(BaseRoute):
-  def setupex(self, slideshow):
+  def setupex(self, slideshow, timekeeper):
     self.slideshow = slideshow
+    self.timekeeper = timekeeper
 
     self.addUrl('/control/<cmd>')
 
   def handle(self, app, cmd):
+    if cmd == 'screenon':
+      self.timekeeper.setManualPower(True)
+      return self.jsonify({'screen': 'on', 'success': True})
+    elif cmd == 'screenoff':
+      self.timekeeper.setManualPower(False)
+      return self.jsonify({'screen': 'off', 'success': True})
+
     self.slideshow.createEvent(cmd)
     return self.jsonify({'control': True})
 


### PR DESCRIPTION
## Summary
- Add `/control/screenon` and `/control/screenoff` HTTP endpoints
- Integrate with timekeeper via new `setManualPower()` method to avoid schedule/sensor conflicts
- Document endpoints in MANUAL.md for home automation use (Home Assistant, Domoticz, etc.)

## Implementation notes
- Uses `timekeeper.setManualPower()` instead of calling `displayMgr.enable()` directly
- This updates the timekeeper's `standby` state so schedule/sensor logic won't immediately undo manual commands
- The next scheduled on/off time or sensor threshold crossing will still apply normally

## Test plan
- [ ] `curl -u photoframe:password http://<ip>:7777/control/screenoff` turns screen off
- [ ] `curl -u photoframe:password http://<ip>:7777/control/screenon` turns screen on
- [ ] Screen stays off until next scheduled "on" time (doesn't fight timekeeper)
- [ ] Existing `/control/<cmd>` endpoints (nextImage, prevImage, etc.) still work
- [ ] Verify on Pi Zero W and Pi 4

Closes #42