### PR TITLE
feat(immich): exponential backoff for network failures

### DIFF
--- a/modules/network.py
+++ b/modules/network.py
@@ -76,3 +76,42 @@ class RequestInvalidToken(Exception):
 
 class RequestExpiredToken(Exception):
     pass
+
+class RequestTerminalError(Exception):
+    """Non-retryable error (bad credentials, not found, etc.)"""
+    pass
+
+
+class RetryConfig:
+    """Exponential backoff configuration for network requests."""
+
+    # HTTP codes that should not be retried
+    TERMINAL_CODES = {401, 403, 404, 410, 422}
+
+    # HTTP codes that indicate transient failures
+    TRANSIENT_CODES = {408, 429, 500, 502, 503, 504}
+
+    def __init__(self, max_retries=6, base_delay=5, max_delay=60, jitter=0.25):
+        self.max_retries = max_retries
+        self.base_delay = base_delay
+        self.max_delay = max_delay
+        self.jitter = jitter
+
+    def get_delay(self, attempt):
+        """Calculate delay for given attempt (0-indexed) with exponential backoff."""
+        import random
+        delay = min(self.base_delay * (2 ** attempt), self.max_delay)
+        if self.jitter > 0:
+            jitter_range = delay * self.jitter
+            delay += random.uniform(-jitter_range, jitter_range)
+        return max(0, delay)
+
+    @classmethod
+    def is_terminal_code(cls, status_code):
+        """Return True if this HTTP code should not be retried."""
+        return status_code in cls.TERMINAL_CODES
+
+    @classmethod
+    def is_transient_code(cls, status_code):
+        """Return True if this HTTP code indicates a transient failure."""
+        return status_code in cls.TRANSIENT_CODES

--- a/modules/network.py
+++ b/modules/network.py
@@ -79,7 +79,9 @@ class RequestExpiredToken(Exception):
 
 class RequestTerminalError(Exception):
     """Non-retryable error (bad credentials, not found, etc.)"""
-    pass
+    def __init__(self, message, status_code=None):
+        super().__init__(message)
+        self.status_code = status_code
 
 
 class RetryConfig:

--- a/services/base.py
+++ b/services/base.py
@@ -28,6 +28,7 @@ from modules.network import RequestResult
 from modules.network import RequestNoNetwork
 from modules.network import RequestInvalidToken
 from modules.network import RequestExpiredToken
+from modules.network import RequestTerminalError
 from modules.images import ImageHolder
 
 from modules.memory import MemoryManager
@@ -622,6 +623,9 @@ class BaseService:
         logging.exception('Cannot fetch due to token issues')
         result = RequestResult().setResult(RequestResult.OAUTH_INVALID)
         self._OAUTH = None
+      except RequestTerminalError as e:
+        logging.error(f'Terminal error fetching image: {e}')
+        result = RequestResult().setResult(RequestResult.UNKNOWN).setHTTPCode(e.status_code or 0)
       except requests.exceptions.RequestException:
         logging.exception('request to download image failed')
         result = RequestResult().setResult(RequestResult.NO_NETWORK)

--- a/services/svc_immich.py
+++ b/services/svc_immich.py
@@ -553,11 +553,12 @@ class Immich(BaseService):
                         logging.warning(f'Network error from Immich: {type(e).__name__}, pausing {delay:.1f}s')
                         time.sleep(delay)
                     else:
-                        logging.error(f'Network unavailable after {retry_config.max_retries} attempts')
-                        raise RequestNoNetwork(f'Failed to connect to Immich: {e}')
+                        logging.error(f'Network unavailable after {retry_config.max_retries} attempts: {e}')
+                        return RequestResult().setResult(RequestResult.NO_NETWORK)
 
             if r is None:
-                raise RequestNoNetwork('No response from Immich server')
+                logging.error('No response from Immich server after retries')
+                return RequestResult().setResult(RequestResult.NO_NETWORK)
 
             result = RequestResult()
             result.setHTTPCode(r.status_code).setHeaders(r.headers).setResult(RequestResult.SUCCESS)

--- a/services/svc_immich.py
+++ b/services/svc_immich.py
@@ -21,7 +21,7 @@ import time
 import requests
 import shutil
 
-from modules.network import RequestResult, RequestNoNetwork
+from modules.network import RequestResult, RequestNoNetwork, RequestTerminalError, RetryConfig
 from modules.helper import helper
 
 
@@ -165,29 +165,49 @@ class Immich(BaseService):
 
         try:
             logging.debug(f'Immich discoverAlbums: calling GET {albums_url}')
-            tries = 0
+            retry_config = RetryConfig()
             response = None
-            while tries < 5:
+
+            for attempt in range(retry_config.max_retries):
                 try:
                     response = requests.get(albums_url, headers=headers, timeout=180)
-                    break
-                except requests.exceptions.RequestException as e:
-                    logging.exception(f'Issues calling Immich albums API, attempt {tries + 1}')
-                    if tries == 4:
+                    if RetryConfig.is_terminal_code(response.status_code):
+                        raise RequestTerminalError(f'Immich returned HTTP {response.status_code}')
+                    if not RetryConfig.is_transient_code(response.status_code):
+                        break  # Success or non-transient
+                    delay = retry_config.get_delay(attempt)
+                    logging.warning(f'Transient HTTP {response.status_code} from Immich, pausing {delay:.1f}s')
+                    time.sleep(delay)
+                except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
+                    delay = retry_config.get_delay(attempt)
+                    if attempt + 1 < retry_config.max_retries:
+                        logging.warning(f'Network error calling Immich: {type(e).__name__}, pausing {delay:.1f}s')
+                        time.sleep(delay)
+                    else:
                         raise RequestNoNetwork(f'Failed to connect to Immich server: {str(e)}')
-                time.sleep(tries * 10)
-                tries += 1
-                logging.warning(f'Retrying Immich albums API call, attempt #{tries + 1}')
+
+            if response is None:
+                raise RequestNoNetwork('No response from Immich server')
+
+            # Log if we exhausted retries on transient errors
+            if RetryConfig.is_transient_code(response.status_code):
+                logging.warning(f'Immich albums API failed after {retry_config.max_retries} retries with HTTP {response.status_code}')
 
             if response.status_code == 200:
                 albums_data = response.json()
                 logging.info(f'Immich discoverAlbums: successfully retrieved {len(albums_data)} albums')
                 return {'success': True, 'albums': albums_data, 'error': None}
-            elif response.status_code == 401:
-                return {'success': False, 'albums': [], 'error': 'Authentication failed. Check your API key.'}
             else:
                 return {'success': False, 'albums': [], 'error': f'Server returned error {response.status_code}'}
 
+        except RequestTerminalError as e:
+            if '401' in str(e):
+                return {'success': False, 'albums': [], 'error': 'Authentication failed. Check your API key.'}
+            elif '403' in str(e):
+                return {'success': False, 'albums': [], 'error': 'Access denied. Check API key permissions.'}
+            elif '404' in str(e):
+                return {'success': False, 'albums': [], 'error': 'Immich server not found. Check server URL.'}
+            return {'success': False, 'albums': [], 'error': str(e)}
         except RequestNoNetwork as e:
             return {'success': False, 'albums': [], 'error': f'Network error: {str(e)}'}
         except Exception as e:
@@ -502,34 +522,49 @@ class Immich(BaseService):
         # Check if this is an Immich URL that needs authentication
         if config and 'server_url' in config and url and url.startswith(config['server_url']):
             headers = {'x-api-key': config['api_key']}
-            
-            tries = 0
-            while tries < 5:
+            retry_config = RetryConfig()
+            r = None
+
+            for attempt in range(retry_config.max_retries):
                 try:
                     if usePost:
                         r = requests.post(url, params=params, json=data, headers=headers, timeout=180)
                     else:
                         r = requests.get(url, params=params, headers=headers, timeout=180, stream=True)
+
+                    # Terminal errors - don't retry, raise immediately
+                    if RetryConfig.is_terminal_code(r.status_code):
+                        logging.error(f'Terminal HTTP {r.status_code} from Immich, not retrying')
+                        raise RequestTerminalError(f'Immich returned HTTP {r.status_code}')
+
+                    # Transient errors - retry with backoff
+                    if RetryConfig.is_transient_code(r.status_code):
+                        delay = retry_config.get_delay(attempt)
+                        logging.warning(f'Transient HTTP {r.status_code} from Immich, pausing {delay:.1f}s')
+                        time.sleep(delay)
+                        continue
+
+                    # Success
                     break
-                except Exception as e:
-                    logging.exception(f'Issues downloading from Immich (attempt {tries + 1})')
-                    if tries == 4:
-                        raise RequestNoNetwork(f'Failed to connect to Immich')
-                
-                time.sleep(tries * 10)
-                tries += 1
-                logging.warning(f'Retrying Immich request, attempt #{tries + 1}')
-            
-            if tries == 5:
-                logging.error('Failed to download from Immich due to network issues')
-                raise RequestNoNetwork('Network timeout')
-            
+
+                except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
+                    delay = retry_config.get_delay(attempt)
+                    if attempt + 1 < retry_config.max_retries:
+                        logging.warning(f'Network error from Immich: {type(e).__name__}, pausing {delay:.1f}s')
+                        time.sleep(delay)
+                    else:
+                        logging.error(f'Network unavailable after {retry_config.max_retries} attempts')
+                        raise RequestNoNetwork(f'Failed to connect to Immich: {e}')
+
+            if r is None:
+                raise RequestNoNetwork('No response from Immich server')
+
             result = RequestResult()
             result.setHTTPCode(r.status_code).setHeaders(r.headers).setResult(RequestResult.SUCCESS)
-            
+
             if r.status_code != 200:
                 logging.error(f'Immich returned status {r.status_code} for {url}')
-                result.setResult(RequestResult.GENERAL_ERROR)
+                result.setResult(RequestResult.UNKNOWN)
                 return result
             
             if destination is None:

--- a/services/svc_immich.py
+++ b/services/svc_immich.py
@@ -172,7 +172,7 @@ class Immich(BaseService):
                 try:
                     response = requests.get(albums_url, headers=headers, timeout=180)
                     if RetryConfig.is_terminal_code(response.status_code):
-                        raise RequestTerminalError(f'Immich returned HTTP {response.status_code}')
+                        raise RequestTerminalError(f'Immich returned HTTP {response.status_code}', status_code=response.status_code)
                     if not RetryConfig.is_transient_code(response.status_code):
                         break  # Success or non-transient
                     delay = retry_config.get_delay(attempt)
@@ -201,11 +201,11 @@ class Immich(BaseService):
                 return {'success': False, 'albums': [], 'error': f'Server returned error {response.status_code}'}
 
         except RequestTerminalError as e:
-            if '401' in str(e):
+            if e.status_code == 401:
                 return {'success': False, 'albums': [], 'error': 'Authentication failed. Check your API key.'}
-            elif '403' in str(e):
+            elif e.status_code == 403:
                 return {'success': False, 'albums': [], 'error': 'Access denied. Check API key permissions.'}
-            elif '404' in str(e):
+            elif e.status_code == 404:
                 return {'success': False, 'albums': [], 'error': 'Immich server not found. Check server URL.'}
             return {'success': False, 'albums': [], 'error': str(e)}
         except RequestNoNetwork as e:
@@ -535,7 +535,7 @@ class Immich(BaseService):
                     # Terminal errors - don't retry, raise immediately
                     if RetryConfig.is_terminal_code(r.status_code):
                         logging.error(f'Terminal HTTP {r.status_code} from Immich, not retrying')
-                        raise RequestTerminalError(f'Immich returned HTTP {r.status_code}')
+                        raise RequestTerminalError(f'Immich returned HTTP {r.status_code}', status_code=r.status_code)
 
                     # Transient errors - retry with backoff
                     if RetryConfig.is_transient_code(r.status_code):


### PR DESCRIPTION
## Summary
- Replaces linear retry (0/10/20/30/40s) with exponential backoff (5/10/20/40/60s cap)
- Distinguishes terminal errors (401/403/404 - fail fast) from transient errors (500/502/503/504 - retry)
- Adds `RetryConfig` utility class to `modules/network.py` for reuse
- Raises `RequestTerminalError` with clear user feedback instead of opaque failures
- Logs "pausing Ns" messages instead of traceback spam

## User-facing changes
- Bad API key: "Authentication failed. Check your API key." (immediate)
- Network down: Calm backoff logs, resumes when network returns
- Server 503: Retries with exponential backoff, gives up after ~3 minutes

## Test plan
- [ ] Misconfigured API key fails fast with clear message
- [ ] `sudo nmcli networking off` mid-slideshow shows backoff logs, not traceback storm
- [ ] Network restore resumes within one backoff interval
- [ ] Immich server 503 retries then gives up gracefully

Closes #46