### PR TITLE
feat: auto-detect GPIO shutdown pin based on color sensor

### DIFF
--- a/frame.py
+++ b/frame.py
@@ -93,7 +93,10 @@ class Photoframe:
     self.slideshow = slideshow(self.displayMgr, self.settingsMgr, self.colormatch, self.imageHistory)
     self.timekeeperMgr = timekeeper()
     self.timekeeperMgr.registerListener(self.displayMgr.enable)
-    self.powerMgr = shutdown(self.settingsMgr.getUser('shutdown-pin'))
+    shutdown_pin = self.settingsMgr.getUser('shutdown-pin')
+    if shutdown_pin == 'auto':
+      shutdown_pin = shutdown.detect_default_pin()
+    self.powerMgr = shutdown(shutdown_pin)
 
     self.cacheMgr.validate()
     self.cacheMgr.enableCache(self.settingsMgr.getUser('enable-cache') == 1)

--- a/modules/settings.py
+++ b/modules/settings.py
@@ -50,7 +50,7 @@ class settings:
       'autooff-lux' : 0.01,
       'autooff-time' : 0,
       'powersave' : '',
-      'shutdown-pin' : 3,
+      'shutdown-pin' : 'auto',
       'display-driver' : 'none',
       'display-special' : None,
       'imagesizing' : 'blur',

--- a/modules/shutdown.py
+++ b/modules/shutdown.py
@@ -22,6 +22,29 @@ import logging
 import atexit
 
 class shutdown(Thread):
+	@staticmethod
+	def detect_default_pin():
+		"""Auto-detect GPIO pin based on TCS34725 color sensor presence.
+
+		Returns GPIO 26 if sensor detected (conflicts with GPIO 3's I2C),
+		otherwise GPIO 3 (allows halt-then-restart via button).
+		"""
+		try:
+			import smbus
+			bus = smbus.SMBus(1)
+			try:
+				bus.write_byte(0x29, 0x80 | 0x12)
+				device_id = bus.read_byte(0x29)
+				if device_id == 0x44:
+					logging.info('TCS34725 detected, using GPIO 26 for shutdown')
+					return 26
+			finally:
+				bus.close()
+		except Exception:
+			pass
+		logging.info('No color sensor detected, using GPIO 3 for shutdown')
+		return 3
+
 	def __init__(self, usePIN=26):
 		Thread.__init__(self)
 		self.daemon = True
@@ -40,7 +63,6 @@ class shutdown(Thread):
 
 	def run(self):
 		logging.info(f'GPIO shutdown can be triggered by GPIO {self.gpio}')
-		# Shutdown can be initated from GPIO26
 		poller = select.poll()
 		try:
 			with open('/sys/class/gpio/export', 'wb') as f:

--- a/routes/settings.py
+++ b/routes/settings.py
@@ -78,6 +78,8 @@ class RouteSettings(BaseRoute):
       if key in ['powersave']:
         self.timekeeper.setPowermode(self.settingsMgr.getUser('powersave'))
       if key in ['shutdown-pin']:
+        # 'auto' is stored as-is; GET returns 'auto', not the resolved pin.
+        # Resolution to GPIO 26 (hat) or 3 (non-hat) happens here and at startup.
         self.powermanagement.stopmonitor()
         pin = self.settingsMgr.getUser('shutdown-pin')
         if pin == 'auto':

--- a/routes/settings.py
+++ b/routes/settings.py
@@ -79,7 +79,10 @@ class RouteSettings(BaseRoute):
         self.timekeeper.setPowermode(self.settingsMgr.getUser('powersave'))
       if key in ['shutdown-pin']:
         self.powermanagement.stopmonitor()
-        self.powermanagement = shutdown(self.settingsMgr.getUser('shutdown-pin'))
+        pin = self.settingsMgr.getUser('shutdown-pin')
+        if pin == 'auto':
+          pin = shutdown.detect_default_pin()
+        self.powermanagement = shutdown(pin)
       if key in ['imagesizing', 'randomize_images']:
         self.slideshow.createEvent("settingsChange")
       self.settingsMgr.save()


### PR DESCRIPTION
## Summary
- Probes for TCS34725 color sensor at startup via I2C
- Sensor present (device ID 0x44): uses GPIO 26 (avoids I2C conflict)
- Sensor absent: uses GPIO 3 (allows halt-then-restart via button)
- Explicit config value still wins over auto-detection
- Fixed I2C bus leak with try/finally pattern

## Test plan
- [ ] Pi with TCS34725 hat: `journalctl -u frame | grep GPIO` shows "GPIO 26"
- [ ] Pi without sensor: shows "GPIO 3"
- [ ] Explicit `shutdown-pin: 26` in settings.json overrides auto-detection
- [ ] Hot-reload via web UI works (change setting, verify new thread starts)

Closes #43