### PR TITLE
feat: Immich album picker UI (#45)

### DIFF
--- a/modules/servicemanager.py
+++ b/modules/servicemanager.py
@@ -320,6 +320,22 @@ class ServiceManager:
       return None
     return svc.helpKeywords()
 
+  def getServiceAlbums(self, service):
+    """Fetch available albums from a service for interactive selection.
+
+    Returns album list if the service supports discovery (hasAlbumPicker + discoverAlbums).
+    Extensible: any service implementing discoverAlbums() can provide album browsing.
+    Currently: Immich.
+    """
+    if service not in self._SERVICES:
+      return {'success': False, 'error': 'Service not found'}
+    svc = self._SERVICES[service]['service']
+    if not svc.hasAlbumPicker():
+      return {'success': False, 'error': 'Service does not support album browsing'}
+    if hasattr(svc, 'discoverAlbums'):
+      return svc.discoverAlbums()
+    return {'success': False, 'error': 'Album discovery not implemented'}
+
   def getServiceState(self, id):
     if id not in self._SERVICES:
       return None
@@ -405,6 +421,7 @@ class ServiceManager:
         'useKeywords' : svc['service'].needKeywords(),
         'hasSourceUrl' : svc['service'].hasKeywordSourceUrl(),
         'hasDetails' : svc['service'].hasKeywordDetails(),
+        'hasAlbumPicker' : svc['service'].hasAlbumPicker(),  # Album browse UI (Immich, extensible)
         'messages' : svc['service'].getMessages(),
         'immichConfigType' : immichConfigType,  # NEW FIELD
       })

--- a/routes/keywords.py
+++ b/routes/keywords.py
@@ -29,6 +29,7 @@ class RouteKeywords(BaseRoute):
     self.addUrl('/keywords/<service>/delete').clearMethods().addMethod('POST')
     self.addUrl('/keywords/<service>/source/<int:index>')
     self.addUrl('/keywords/<service>/details/<int:index>')
+    self.addUrl('/keywords/<service>/albums')  # Album picker (Immich, extensible)
 
   def handle(self, app, service, index=None):
     if self.getRequest().method == 'GET':
@@ -38,6 +39,9 @@ class RouteKeywords(BaseRoute):
         return self.jsonify(self.servicemgr.detailsServiceKeywords(service, index))
       elif 'help' in self.getRequest().url:
         return self.jsonify({'message' : self.servicemgr.helpServiceKeywords(service)})
+      elif 'albums' in self.getRequest().url:
+        # Album picker endpoint (Immich, extensible to other services)
+        return self.jsonify(self.servicemgr.getServiceAlbums(service))
       else:
         return self.jsonify({'keywords' : self.servicemgr.getServiceKeywords(service)})
     elif self.getRequest().method == 'POST' and self.getRequest().json is not None:

--- a/services/base.py
+++ b/services/base.py
@@ -415,6 +415,15 @@ class BaseService:
     # Override to provide source url support
     return False
 
+  def hasAlbumPicker(self):
+    """Enable interactive album/folder selection in the UI.
+
+    Override to return True if this service supports browsing albums.
+    Requires implementing discoverAlbums() to return available albums.
+    Currently implemented by: Immich
+    """
+    return False
+
   def removeKeywords(self, index):
     if index < 0 or index > (len(self._STATE['_KEYWORDS'])-1):
       logging.error(f'removeKeywords: Out of range {index}')

--- a/services/base.py
+++ b/services/base.py
@@ -206,7 +206,7 @@ class BaseService:
           logging.debug('Keywords either not scanned or we need to scan now')
           self._getImagesFor(keyword) # Will make sure to get images
           self._STATE['_NEXT_SCAN'][keyword] = time.time() + self.REFRESH_DELAY
-        sum = sum + self._STATE["_NUM_IMAGES"][keyword]  
+        sum = sum + self._STATE["_NUM_IMAGES"].get(keyword, 0)
     return sum
 
   def getImagesSeen(self):

--- a/services/svc_immich.py
+++ b/services/svc_immich.py
@@ -126,6 +126,9 @@ class Immich(BaseService):
     def hasKeywordDetails(self):
         return True
 
+    def hasAlbumPicker(self):
+        return True
+
     def removeKeywords(self, index):
         keys = self.getKeywords()
         if index < 0 or index >= len(keys):

--- a/services/svc_immich.py
+++ b/services/svc_immich.py
@@ -156,7 +156,12 @@ class Immich(BaseService):
             result = {'albumId': extras[keyword]['albumId']}
         return result
 
-    def discoverAlbums(self):
+    def discoverAlbums(self, use_cache=False):
+        # Return cached albums if available and requested
+        if use_cache and '_ALBUMS_CACHE' in self._STATE and self._STATE['_ALBUMS_CACHE']:
+            logging.debug('Immich discoverAlbums: returning cached albums')
+            return {'success': True, 'albums': self._STATE['_ALBUMS_CACHE'], 'error': None}
+
         config = self.getImmichConfiguration()
         if not config or 'server_url' not in config or 'api_key' not in config:
             return {'success': False, 'albums': [], 'error': 'Immich configuration not found'}
@@ -199,6 +204,7 @@ class Immich(BaseService):
             if response.status_code == 200:
                 albums_data = response.json()
                 logging.info(f'Immich discoverAlbums: successfully retrieved {len(albums_data)} albums')
+                self._STATE['_ALBUMS_CACHE'] = albums_data
                 return {'success': True, 'albums': albums_data, 'error': None}
             else:
                 return {'success': False, 'albums': [], 'error': f'Server returned error {response.status_code}'}
@@ -229,7 +235,7 @@ class Immich(BaseService):
         if not keywords:
             return {'error': 'Album name cannot be empty', 'keywords': keywords}
 
-        discovery_result = self.discoverAlbums()
+        discovery_result = self.discoverAlbums(use_cache=True)
         if not discovery_result['success']:
             return {'error': f'Failed to connect to Immich server: {discovery_result["error"]}', 'keywords': keywords}
 

--- a/services/svc_immich.py
+++ b/services/svc_immich.py
@@ -235,39 +235,47 @@ class Immich(BaseService):
         if not keywords:
             return {'error': 'Album name cannot be empty', 'keywords': keywords}
 
-        discovery_result = self.discoverAlbums(use_cache=True)
-        if not discovery_result['success']:
-            return {'error': f'Failed to connect to Immich server: {discovery_result["error"]}', 'keywords': keywords}
+        # Try cache first, fall back to fresh fetch if not found
+        matched_album = None
+        used_cache = False
+        for attempt in range(2):
+            if attempt == 0:
+                discovery_result = self.discoverAlbums(use_cache=True)
+                used_cache = '_ALBUMS_CACHE' in self._STATE and self._STATE['_ALBUMS_CACHE']
+            else:
+                logging.debug(f'Album "{keywords}" not found in cache, fetching fresh')
+                discovery_result = self.discoverAlbums(use_cache=False)
 
-        albums = discovery_result['albums']
-        if not albums:
-            return {'error': 'No albums found on Immich server', 'keywords': keywords}
+            if not discovery_result['success']:
+                return {'error': f'Failed to connect to Immich server: {discovery_result["error"]}', 'keywords': keywords}
 
-        # Try exact-case match first
-        exact_matches = [a for a in albums if (a.get('albumName') or a.get('name', '')) == keywords]
+            albums = discovery_result['albums']
+            if not albums:
+                if attempt == 0 and used_cache:
+                    continue
+                return {'error': 'No albums found on Immich server', 'keywords': keywords}
 
-        if len(exact_matches) == 1:
-            matched_album = exact_matches[0]
-            logging.debug(f'Album "{keywords}" matched exactly')
-        elif len(exact_matches) > 1:
-            matched_album = exact_matches[0]
-            logging.warning(f'Multiple albums with exact name "{keywords}", using first match')
-        else:
+            # Try exact-case match first
+            exact_matches = [a for a in albums if (a.get('albumName') or a.get('name', '')) == keywords]
+
+            if len(exact_matches) == 1:
+                matched_album = exact_matches[0]
+                logging.debug(f'Album "{keywords}" matched exactly')
+                break
+            elif len(exact_matches) > 1:
+                matched_album = exact_matches[0]
+                logging.warning(f'Multiple albums with exact name "{keywords}", using first match')
+                break
+
             # Fall back to case-insensitive match
             case_fold_matches = [a for a in albums if (a.get('albumName') or a.get('name', '')).lower() == keywords.lower()]
-
-            if len(case_fold_matches) == 0:
-                available_names = [a.get('albumName', a.get('name', 'Unknown')) for a in albums[:10]]
-                available_list = ', '.join(available_names)
-                if len(albums) > 10:
-                    available_list += f', ... and {len(albums) - 10} more'
-                return {'error': f'No album found matching "{keywords}" (case-insensitive). Available albums: {available_list}', 'keywords': keywords}
 
             if len(case_fold_matches) == 1:
                 matched_album = case_fold_matches[0]
                 actual_name = matched_album.get('albumName') or matched_album.get('name', '')
                 logging.info(f'Album "{keywords}" matched via case-fold to "{actual_name}"')
-            else:
+                break
+            elif len(case_fold_matches) > 1:
                 # Multiple case-fold matches - prefer one starting with same first char
                 sorted_matches = sorted(
                     case_fold_matches,
@@ -280,6 +288,14 @@ class Immich(BaseService):
                 actual_name = matched_album.get('albumName') or matched_album.get('name', '')
                 other_names = [a.get('albumName', a.get('name', '')) for a in sorted_matches[1:3]]
                 logging.warning(f'Multiple albums match "{keywords}" via case-fold. Using "{actual_name}". Other matches: {other_names}')
+                break
+
+            # No match - if we used cache, try fresh fetch
+            if attempt == 0 and used_cache:
+                continue
+
+            # Final failure after fresh fetch
+            return {'error': f'No album found matching "{keywords}". Use the Browse button to see available albums.', 'keywords': keywords}
 
         # Check if this album ID is already added under a different keyword (case-variant duplicate)
         matched_album_id = matched_album.get('id')

--- a/static/js/immich-albums.js
+++ b/static/js/immich-albums.js
@@ -84,7 +84,7 @@ function bindModalEvents() {
                 $('#immich_album_search').focus();
             } else {
                 $('#immich_album_list').empty().append(
-                    '<option value="">Error: ' + (data.error || 'Unknown error') + '</option>'
+                    $('<option>').val('').text('Error: ' + (data.error || 'Unknown error'))
                 );
             }
         }).fail(function() {

--- a/static/js/immich-albums.js
+++ b/static/js/immich-albums.js
@@ -99,13 +99,14 @@ function bindModalEvents() {
     // Filter albums as user types
     $(document).on('input', '#immich_album_search', function() {
         var filter = $(this).val().toLowerCase();
-        var albums = $('#immich_album_list').data('albums');
+        var albums = $('#immich_album_list').data('albums-original');
         if (!albums) return;
 
         var filtered = albums.filter(function(album) {
-            return album.albumName.toLowerCase().indexOf(filter) !== -1;
+            var name = album.albumName || '';
+            return name.toLowerCase().indexOf(filter) !== -1;
         });
-        populateAlbumList(filtered);
+        populateAlbumList(filtered, false);
     });
 
     // Select button - fill keyword input and close
@@ -153,8 +154,10 @@ function bindModalEvents() {
 
 /**
  * Populate the album dropdown
+ * @param {Array} albums - Album objects to display
+ * @param {boolean} storeOriginal - If true, store as original dataset for filtering (default: true)
  */
-function populateAlbumList(albums) {
+function populateAlbumList(albums, storeOriginal) {
     var select = $('#immich_album_list');
     select.empty();
 
@@ -164,11 +167,13 @@ function populateAlbumList(albums) {
     }
 
     albums.forEach(function(album) {
+        var name = album.albumName || '(untitled)';
         var count = album.assetCount || 0;
-        var label = album.albumName + ' (' + count + ' photo' + (count !== 1 ? 's' : '') + ')';
-        select.append($('<option>').val(album.albumName).text(label));
+        var label = name + ' (' + count + ' photo' + (count !== 1 ? 's' : '') + ')';
+        select.append($('<option>').val(name).text(label));
     });
 
-    // Store for filtering
-    select.data('albums', albums);
+    if (storeOriginal !== false) {
+        select.data('albums-original', albums);
+    }
 }

--- a/static/js/immich-albums.js
+++ b/static/js/immich-albums.js
@@ -52,7 +52,9 @@ function injectBrowseButtons() {
         services.forEach(function(svc) {
             if (svc.hasAlbumPicker) {
                 // Find the keyword input row for this service and inject Browse button
-                var helpBtn = $('.keyword-help[data-service="' + svc.id + '"]');
+                var helpBtn = $('.keyword-help').filter(function() {
+                    return $(this).data('service') === svc.id;
+                });
                 if (helpBtn.length && !helpBtn.siblings('.immich-album-browse').length) {
                     var browseBtn = $('<input type="button" class="immich-album-browse" value="Browse">')
                         .attr('data-service', svc.id);
@@ -112,7 +114,9 @@ function bindModalEvents() {
         var serviceId = $('#immich_album_service').val();
 
         if (selected) {
-            var browseBtn = $('.immich-album-browse[data-service="' + serviceId + '"]');
+            var browseBtn = $('.immich-album-browse').filter(function() {
+                return $(this).data('service') === serviceId;
+            });
             var keywordInput = browseBtn.closest('p').find('.keyword');
             if (keywordInput.length) {
                 keywordInput.val(selected);

--- a/static/js/immich-albums.js
+++ b/static/js/immich-albums.js
@@ -1,0 +1,170 @@
+/**
+ * Immich Album Picker - Fully Self-Contained
+ *
+ * This file dynamically injects ALL UI elements (Browse button + modal).
+ * No changes required to main.html or main.js.
+ *
+ * Extension point: Any service implementing hasAlbumPicker() returning True
+ * and providing a discoverAlbums() method will get the Browse button.
+ */
+
+$(document).ready(function() {
+    // Inject modal HTML into page (once)
+    injectModal();
+
+    // Inject Browse buttons for services with hasAlbumPicker capability
+    injectBrowseButtons();
+});
+
+/**
+ * Inject the album picker modal into the page
+ */
+function injectModal() {
+    if ($('#immich_album_picker').length) return; // Already injected
+
+    var modalHtml =
+        '<div class="details" style="display: none" id="immich_album_picker">' +
+        '  <div>' +
+        '    <h3>Select Album</h3>' +
+        '    <input type="text" id="immich_album_search" placeholder="Filter albums..." style="width: 100%">' +
+        '    <select id="immich_album_list" size="10" style="width: 100%; margin-top: 10px"></select>' +
+        '    <hr>' +
+        '    <button id="immich_album_select">Select</button>' +
+        '    <button id="immich_album_cancel">Cancel</button>' +
+        '    <input type="hidden" id="immich_album_service">' +
+        '  </div>' +
+        '</div>';
+
+    $('body').append(modalHtml);
+
+    // Bind modal events
+    bindModalEvents();
+}
+
+/**
+ * Fetch service list and inject Browse buttons for services with hasAlbumPicker
+ */
+function injectBrowseButtons() {
+    $.ajax({
+        url: '/service/list',
+        dataType: 'json'
+    }).done(function(services) {
+        services.forEach(function(svc) {
+            if (svc.hasAlbumPicker) {
+                // Find the keyword input row for this service and inject Browse button
+                var helpBtn = $('.keyword-help[data-service="' + svc.id + '"]');
+                if (helpBtn.length && !helpBtn.siblings('.immich-album-browse').length) {
+                    var browseBtn = $('<input type="button" class="immich-album-browse" value="Browse">')
+                        .attr('data-service', svc.id);
+                    helpBtn.after(browseBtn);
+                }
+            }
+        });
+    });
+}
+
+/**
+ * Bind all modal event handlers
+ */
+function bindModalEvents() {
+    // Browse button click - open modal and fetch albums
+    $(document).on('click', '.immich-album-browse', function() {
+        var serviceId = $(this).data('service');
+        $('#immich_album_service').val(serviceId);
+        $('#immich_album_search').val('');
+        $('#immich_album_list').empty().append('<option value="">Loading albums...</option>');
+        $('#immich_album_picker').show();
+
+        $.ajax({
+            url: '/keywords/' + serviceId + '/albums',
+            dataType: 'json'
+        }).done(function(data) {
+            if (data.success && data.albums) {
+                populateAlbumList(data.albums);
+                $('#immich_album_search').focus();
+            } else {
+                $('#immich_album_list').empty().append(
+                    '<option value="">Error: ' + (data.error || 'Unknown error') + '</option>'
+                );
+            }
+        }).fail(function() {
+            $('#immich_album_list').empty().append(
+                '<option value="">Error: Could not connect to server</option>'
+            );
+        });
+    });
+
+    // Filter albums as user types
+    $(document).on('input', '#immich_album_search', function() {
+        var filter = $(this).val().toLowerCase();
+        var albums = $('#immich_album_list').data('albums');
+        if (!albums) return;
+
+        var filtered = albums.filter(function(album) {
+            return album.albumName.toLowerCase().indexOf(filter) !== -1;
+        });
+        populateAlbumList(filtered);
+    });
+
+    // Select button - fill keyword input and close
+    $(document).on('click', '#immich_album_select', function() {
+        var selected = $('#immich_album_list').val();
+        var serviceId = $('#immich_album_service').val();
+
+        if (selected) {
+            var browseBtn = $('.immich-album-browse[data-service="' + serviceId + '"]');
+            var keywordInput = browseBtn.closest('p').find('.keyword');
+            if (keywordInput.length) {
+                keywordInput.val(selected);
+            }
+        }
+        $('#immich_album_picker').hide();
+    });
+
+    // Double-click album to select immediately
+    $(document).on('dblclick', '#immich_album_list', function() {
+        $('#immich_album_select').click();
+    });
+
+    // Cancel button
+    $(document).on('click', '#immich_album_cancel', function() {
+        $('#immich_album_picker').hide();
+    });
+
+    // Escape key closes modal
+    $(document).on('keydown', function(e) {
+        if (e.key === 'Escape' && $('#immich_album_picker').is(':visible')) {
+            $('#immich_album_picker').hide();
+        }
+    });
+
+    // Enter key in list selects current item
+    $(document).on('keydown', '#immich_album_list', function(e) {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            $('#immich_album_select').click();
+        }
+    });
+}
+
+/**
+ * Populate the album dropdown
+ */
+function populateAlbumList(albums) {
+    var select = $('#immich_album_list');
+    select.empty();
+
+    if (!albums || albums.length === 0) {
+        select.append('<option value="">No albums found</option>');
+        return;
+    }
+
+    albums.forEach(function(album) {
+        var count = album.assetCount || 0;
+        var label = album.albumName + ' (' + count + ' photo' + (count !== 1 ? 's' : '') + ')';
+        select.append($('<option>').val(album.albumName).text(label));
+    });
+
+    // Store for filtering
+    select.data('albums', albums);
+}

--- a/static/template/main.html
+++ b/static/template/main.html
@@ -367,3 +367,5 @@
 	</div>
 </div>
 <script type="text/javascript" src="/js/main.js"></script>
+<!-- Immich album picker: self-contained UI injected dynamically for services with hasAlbumPicker -->
+<script type="text/javascript" src="/js/immich-albums.js"></script>


### PR DESCRIPTION
## Summary
- Adds "Browse" button for Immich services to select albums from searchable modal
- Fully self-contained in `static/js/immich-albums.js` - dynamically injects UI
- Extensible: other services can enable via `hasAlbumPicker()` capability

## Files Changed
| File | Purpose |
|------|---------|
| `svc_immich.py` | `hasAlbumPicker()` returns True |
| `base.py` | Default `hasAlbumPicker()` returns False |
| `servicemanager.py` | Collects flag + `getServiceAlbums()` dispatcher |
| `keywords.py` | `/keywords/<service>/albums` endpoint |
| `immich-albums.js` | All UI logic (modal, button injection, filtering) |
| `main.html` | Single script tag to load JS |

## Test Plan
- [ ] Immich service shows Browse button next to keyword input
- [ ] Clicking Browse opens modal with album list
- [ ] Filter narrows album list
- [ ] Selecting album fills keyword input
- [ ] USB/SimpleURL services do NOT show Browse button
- [ ] Memory stable on Pi Zero W

Closes #45