### PR TITLE
fix: case-fold album name lookup (#53)

### DIFF
--- a/services/svc_immich.py
+++ b/services/svc_immich.py
@@ -214,15 +214,31 @@ class Immich(BaseService):
         if not albums:
             return {'error': 'No albums found on Immich server', 'keywords': keywords}
 
-        matching_albums = [a for a in albums if (a.get('albumName') or a.get('name', '')).lower() == keywords.lower()]
-        if len(matching_albums) == 0:
-            available_names = [a.get('albumName', a.get('name', 'Unknown')) for a in albums[:10]]
-            available_list = ', '.join(available_names)
-            if len(albums) > 10:
-                available_list += f', ... and {len(albums) - 10} more'
-            return {'error': f'No album found with name "{keywords}". Available albums: {available_list}', 'keywords': keywords}
+        # Try exact-case match first
+        exact_matches = [a for a in albums if (a.get('albumName') or a.get('name', '')) == keywords]
+        if exact_matches:
+            matched_album = exact_matches[0]
+        else:
+            # Fall back to case-insensitive match
+            keywords_lower = keywords.lower()
+            case_fold_matches = [a for a in albums if (a.get('albumName') or a.get('name', '')).lower() == keywords_lower]
 
-        matched_album = matching_albums[0]
+            if not case_fold_matches:
+                available_names = [a.get('albumName', a.get('name', 'Unknown')) for a in albums[:10]]
+                available_list = ', '.join(available_names)
+                if len(albums) > 10:
+                    available_list += f', ... and {len(albums) - 10} more'
+                return {'error': f'No album found with name "{keywords}". Available albums: {available_list}', 'keywords': keywords}
+
+            matched_album = case_fold_matches[0]
+            actual_name = matched_album.get('albumName') or matched_album.get('name', '')
+
+            if len(case_fold_matches) > 1:
+                # Multiple case-fold matches - log warning with all matches
+                match_names = [a.get('albumName') or a.get('name', '') for a in case_fold_matches]
+                logging.warning(f'Multiple albums match "{keywords}" via case-fold: {match_names}. Using "{actual_name}"')
+            else:
+                logging.info(f'Album "{keywords}" matched via case-fold to "{actual_name}"')
         config = self.getImmichConfiguration()
         server_url = config.get('server_url', '') if config else ''
 


### PR DESCRIPTION
## Summary
- Try exact-case album match first
- Fall back to case-insensitive if no exact match
- Log info when case-folding resolves a match
- Log warning when multiple albums match via case-fold

## Files Changed
| File | Change |
|------|--------|
| `svc_immich.py` | Updated `validateKeywords()` matching logic |

No shared files modified.

## Test Plan
- [ ] Enter `family photos` when album is named `Family Photos` → should match
- [ ] Enter `FAMILY PHOTOS` → should match, log shows case-fold used
- [ ] Enter exact case `Family Photos` → should match, no case-fold log
- [ ] Create two albums `Test` and `test` → entering `TEST` logs warning about multiple matches

Closes #53