### PR TITLE
feat: HTTP screen on/off endpoints (#42)

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -156,6 +156,30 @@ are `photoframe` / `password` (change via `http-auth.json` in
 `/root/photoframe_config/`). Choose your photo service (Immich is the
 supported default; Google Photos is deprecated) and follow the prompts.
 
+# http api
+
+The photoframe exposes HTTP endpoints for integration with home automation
+systems (Home Assistant, Domoticz, etc.). All endpoints require HTTP Basic
+Auth using the same credentials as the web UI.
+
+## screen control
+
+Turn the display on or off remotely:
+
+```bash
+# Turn screen off
+curl -u photoframe:password http://<pi-ip>:7777/control/screenoff
+
+# Turn screen on
+curl -u photoframe:password http://<pi-ip>:7777/control/screenon
+```
+
+Both endpoints return JSON: `{"screen": "on", "success": true}` or
+`{"screen": "off", "success": true}`.
+
+Note: A scheduled power-saving tick may override manual screen state.
+For persistent control, adjust the schedule in the web UI.
+
 # wifi setup
 
 **Bookworm uses NetworkManager** for all network configuration. The

--- a/frame.py
+++ b/frame.py
@@ -147,7 +147,7 @@ class Photoframe:
     self._loadRoute('configupload', 'RouteConfigUpload', self.serviceMgr, self.slideshow)
     self._loadRoute('immichconfigupload', 'RouteImmichConfigUpload', self.serviceMgr, self.slideshow)
     self._loadRoute('service', 'RouteService', self.serviceMgr, self.slideshow)
-    self._loadRoute('control', 'RouteControl', self.slideshow)
+    self._loadRoute('control', 'RouteControl', self.slideshow, self.displayMgr)
     self._loadRoute('events', 'RouteEvents', self.eventMgr)
     self._loadRoute('debug', 'RouteDebug', self.displayMgr)
 

--- a/routes/control.py
+++ b/routes/control.py
@@ -19,12 +19,21 @@
 from .baseroute import BaseRoute
 
 class RouteControl(BaseRoute):
-  def setupex(self, slideshow):
+  def setupex(self, slideshow, displayMgr):
     self.slideshow = slideshow
+    self.displayMgr = displayMgr
 
     self.addUrl('/control/<cmd>')
 
   def handle(self, app, cmd):
+    # Screen on/off endpoints for home automation integration
+    if cmd == 'screenon':
+      self.displayMgr.enable(True)
+      return self.jsonify({'screen': 'on', 'success': True})
+    elif cmd == 'screenoff':
+      self.displayMgr.enable(False)
+      return self.jsonify({'screen': 'off', 'success': True})
+
     self.slideshow.createEvent(cmd)
     return self.jsonify({'control': True})
 


### PR DESCRIPTION
## Summary
- Add `/control/screenon` and `/control/screenoff` endpoints
- Wrap `displayMgr.enable(True|False)` for home automation integration
- Document in MANUAL.md with curl examples

## Files Changed
| File | Change |
|------|--------|
| `routes/control.py` | Add screenon/screenoff handlers |
| `frame.py` | Pass displayMgr to RouteControl |
| `MANUAL.md` | Document HTTP API section |

## Test Plan
- [ ] `curl -u photoframe:password http://<ip>:7777/control/screenoff` blanks display
- [ ] `curl -u photoframe:password http://<ip>:7777/control/screenon` wakes display
- [ ] Unauthenticated request returns 401
- [ ] Existing `/control/<cmd>` slideshow commands still work

Closes #42