### PR TITLE
feat: image prioritization dropdown (#47)

### DIFF
--- a/modules/servicemanager.py
+++ b/modules/servicemanager.py
@@ -336,6 +336,39 @@ class ServiceManager:
       return svc.discoverAlbums()
     return {'success': False, 'error': 'Album discovery not implemented'}
 
+  def getServicePrioritization(self, service):
+    """Get prioritization setting for a service.
+
+    Returns current mode and available modes if service supports prioritization.
+    Extensible: any service implementing hasPrioritization() can use this.
+    Currently: Immich.
+    """
+    if service not in self._SERVICES:
+      return {'success': False, 'error': 'Service not found'}
+    svc = self._SERVICES[service]['service']
+    if not svc.hasPrioritization():
+      return {'success': False, 'error': 'Service does not support prioritization'}
+    return {
+      'success': True,
+      'current': svc.getPrioritization(),
+      'modes': svc.getPrioritizationModes()
+    }
+
+  def setServicePrioritization(self, service, mode):
+    """Set prioritization mode for a service.
+
+    Extensible: any service implementing hasPrioritization() can use this.
+    Currently: Immich.
+    """
+    if service not in self._SERVICES:
+      return {'success': False, 'error': 'Service not found'}
+    svc = self._SERVICES[service]['service']
+    if not svc.hasPrioritization():
+      return {'success': False, 'error': 'Service does not support prioritization'}
+    if svc.setPrioritization(mode):
+      return {'success': True, 'mode': mode}
+    return {'success': False, 'error': 'Invalid prioritization mode'}
+
   def getServiceState(self, id):
     if id not in self._SERVICES:
       return None
@@ -422,6 +455,7 @@ class ServiceManager:
         'hasSourceUrl' : svc['service'].hasKeywordSourceUrl(),
         'hasDetails' : svc['service'].hasKeywordDetails(),
         'hasAlbumPicker' : svc['service'].hasAlbumPicker(),  # Album browse UI (Immich, extensible)
+        'hasPrioritization' : svc['service'].hasPrioritization(),  # Prioritization UI (Immich, extensible)
         'messages' : svc['service'].getMessages(),
         'immichConfigType' : immichConfigType,  # NEW FIELD
       })

--- a/routes/keywords.py
+++ b/routes/keywords.py
@@ -30,6 +30,8 @@ class RouteKeywords(BaseRoute):
     self.addUrl('/keywords/<service>/source/<int:index>')
     self.addUrl('/keywords/<service>/details/<int:index>')
     self.addUrl('/keywords/<service>/albums')  # Album picker (Immich, extensible)
+    self.addUrl('/keywords/<service>/prioritization')  # Prioritization settings (Immich, extensible)
+    self.addUrl('/keywords/<service>/prioritization').clearMethods().addMethod('POST')
 
   def handle(self, app, service, index=None):
     if self.getRequest().method == 'GET':
@@ -42,25 +44,36 @@ class RouteKeywords(BaseRoute):
       elif 'albums' in self.getRequest().url:
         # Album picker endpoint (Immich, extensible to other services)
         return self.jsonify(self.servicemgr.getServiceAlbums(service))
+      elif 'prioritization' in self.getRequest().url:
+        # Prioritization settings endpoint (Immich, extensible to other services)
+        return self.jsonify(self.servicemgr.getServicePrioritization(service))
       else:
         return self.jsonify({'keywords' : self.servicemgr.getServiceKeywords(service)})
-    elif self.getRequest().method == 'POST' and self.getRequest().json is not None:
-      result = True
-      if 'id' not in self.getRequest().json:
-        hadKeywords = self.servicemgr.hasKeywords()
-        result = self.servicemgr.addServiceKeywords(service, self.getRequest().json['keywords'])
-        if result['error'] is not None:
-          result['status'] = False
+    elif self.getRequest().method == 'POST':
+      # Handle prioritization POST separately
+      if 'prioritization' in self.getRequest().url:
+        if self.getRequest().json is None:
+          return self.jsonify({'success': False, 'error': 'JSON body required'})
+        mode = self.getRequest().json.get('mode', 'none')
+        return self.jsonify(self.servicemgr.setServicePrioritization(service, mode))
+      # Handle keyword add/delete
+      if self.getRequest().json is not None:
+        result = True
+        if 'id' not in self.getRequest().json:
+          hadKeywords = self.servicemgr.hasKeywords()
+          result = self.servicemgr.addServiceKeywords(service, self.getRequest().json['keywords'])
+          if result['error'] is not None:
+            result['status'] = False
+          else:
+            result['status'] = True
+            if hadKeywords != self.servicemgr.hasKeywords():
+              # Make slideshow show the change immediately, we have keywords
+              self.slideshow.trigger()
         else:
-          result['status'] = True
-          if hadKeywords != self.servicemgr.hasKeywords():
-            # Make slideshow show the change immediately, we have keywords
+          if not self.servicemgr.removeServiceKeywords(service, self.getRequest().json['id']):
+            result = {'status':False, 'error' : 'Unable to remove keyword'}
+          else:
+            # Trigger slideshow, we have removed some keywords
             self.slideshow.trigger()
-      else:
-        if not self.servicemgr.removeServiceKeywords(service, self.getRequest().json['id']):
-          result = {'status':False, 'error' : 'Unable to remove keyword'}
-        else:
-          # Trigger slideshow, we have removed some keywords
-          self.slideshow.trigger()
-      return self.jsonify(result)
+        return self.jsonify(result)
     self.setAbort(500)

--- a/services/base.py
+++ b/services/base.py
@@ -424,6 +424,15 @@ class BaseService:
     """
     return False
 
+  def hasPrioritization(self):
+    """Enable image prioritization UI (sort/filter options).
+
+    Override to return True if this service supports prioritization modes.
+    Requires implementing getPrioritization(), setPrioritization(), getPrioritizationModes().
+    Currently implemented by: Immich
+    """
+    return False
+
   def removeKeywords(self, index):
     if index < 0 or index > (len(self._STATE['_KEYWORDS'])-1):
       logging.error(f'removeKeywords: Out of range {index}')

--- a/services/svc_immich.py
+++ b/services/svc_immich.py
@@ -129,6 +129,64 @@ class Immich(BaseService):
     def hasAlbumPicker(self):
         return True
 
+    # ------------------ Prioritization ------------------
+
+    PRIORITIZATION_MODES = {
+        'none': 'No prioritization (default)',
+        'recent_added': 'Recently added to Immich',
+        'recent_taken': 'Recently taken (by date)',
+        'favorites_only': 'Favorites only',
+        'favorites_first': 'Favorites first, then others'
+    }
+
+    def hasPrioritization(self):
+        return True
+
+    def getPrioritization(self):
+        return self._STATE.get('_PRIORITIZATION', 'none')
+
+    def setPrioritization(self, mode):
+        if mode not in self.PRIORITIZATION_MODES:
+            return False
+        self._STATE['_PRIORITIZATION'] = mode
+        self.saveState()
+        return True
+
+    def getPrioritizationModes(self):
+        return self.PRIORITIZATION_MODES
+
+    def _applyPrioritization(self, assets):
+        mode = self.getPrioritization()
+        if mode == 'none' or not assets:
+            return assets
+
+        if mode == 'favorites_only':
+            filtered = [a for a in assets if a.get('isFavorite', False)]
+            if filtered:
+                logging.info(f'Prioritization: filtered to {len(filtered)} favorites from {len(assets)} assets')
+                return filtered
+            logging.warning('Prioritization: no favorites found, returning all assets')
+            return assets
+
+        if mode == 'favorites_first':
+            favorites = [a for a in assets if a.get('isFavorite', False)]
+            others = [a for a in assets if not a.get('isFavorite', False)]
+            result = favorites + others
+            logging.info(f'Prioritization: {len(favorites)} favorites first, then {len(others)} others')
+            return result
+
+        if mode == 'recent_added':
+            sorted_assets = sorted(assets, key=lambda a: a.get('createdAt', ''), reverse=True)
+            logging.info(f'Prioritization: sorted {len(sorted_assets)} assets by createdAt (recent first)')
+            return sorted_assets
+
+        if mode == 'recent_taken':
+            sorted_assets = sorted(assets, key=lambda a: a.get('fileCreatedAt', '') or a.get('createdAt', ''), reverse=True)
+            logging.info(f'Prioritization: sorted {len(sorted_assets)} assets by fileCreatedAt (recent first)')
+            return sorted_assets
+
+        return assets
+
     def removeKeywords(self, index):
         keys = self.getKeywords()
         if index < 0 or index >= len(keys):
@@ -366,6 +424,9 @@ class Immich(BaseService):
                 return []
 
             logging.info(f'Retrieved {len(assets)} assets from album "{keyword}"')
+
+            # Apply prioritization (sorting/filtering based on user preference)
+            assets = self._applyPrioritization(assets)
 
         except Exception as e:
             logging.error(f'Failed to get images for keyword "{keyword}": {e}')

--- a/static/js/immich-prioritization.js
+++ b/static/js/immich-prioritization.js
@@ -34,11 +34,16 @@ function injectPrioritizationDropdowns() {
  */
 function injectDropdownForService(serviceId) {
     // Find the service section and the keyword area
-    var keywordHelp = $('.keyword-help[data-service="' + serviceId + '"]');
+    var keywordHelp = $('.keyword-help').filter(function() {
+        return $(this).data('service') === serviceId;
+    });
     if (!keywordHelp.length) return;
 
     // Check if already injected
-    if ($('.immich-prioritization[data-service="' + serviceId + '"]').length) return;
+    var existing = $('.immich-prioritization').filter(function() {
+        return $(this).data('service') === serviceId;
+    });
+    if (existing.length) return;
 
     // Fetch current prioritization settings
     $.ajax({
@@ -47,21 +52,24 @@ function injectDropdownForService(serviceId) {
     }).done(function(data) {
         if (!data.success) return;
 
-        // Build dropdown HTML
-        var html = '<p class="nospace" style="margin-top: 5px;">' +
-            '<label style="margin-right: 5px;">Image order:</label>' +
-            '<select class="immich-prioritization" data-service="' + serviceId + '">';
+        // Build dropdown using jQuery element creation
+        var select = $('<select class="immich-prioritization">').attr('data-service', serviceId);
 
         for (var mode in data.modes) {
-            var selected = (mode === data.current) ? ' selected' : '';
-            html += '<option value="' + mode + '"' + selected + '>' + data.modes[mode] + '</option>';
+            var option = $('<option>').val(mode).text(data.modes[mode]);
+            if (mode === data.current) {
+                option.prop('selected', true);
+            }
+            select.append(option);
         }
 
-        html += '</select></p>';
+        var wrapper = $('<p class="nospace" style="margin-top: 5px;">')
+            .append($('<label style="margin-right: 5px;">').text('Image order:'))
+            .append(select);
 
         // Insert after the keyword input row
         var keywordRow = keywordHelp.closest('p');
-        keywordRow.after(html);
+        keywordRow.after(wrapper);
     });
 }
 

--- a/static/js/immich-prioritization.js
+++ b/static/js/immich-prioritization.js
@@ -1,0 +1,99 @@
+/**
+ * Immich Prioritization UI - Fully Self-Contained
+ *
+ * This file dynamically injects a prioritization dropdown for Immich services.
+ * No changes required to main.html or main.js.
+ *
+ * Extension point: Any service implementing hasPrioritization() returning True
+ * and providing getPrioritization/setPrioritization/getPrioritizationModes methods.
+ */
+
+$(document).ready(function() {
+    // Inject prioritization dropdowns for services with hasPrioritization capability
+    injectPrioritizationDropdowns();
+});
+
+/**
+ * Fetch service list and inject prioritization dropdown for services with hasPrioritization
+ */
+function injectPrioritizationDropdowns() {
+    $.ajax({
+        url: '/service/list',
+        dataType: 'json'
+    }).done(function(services) {
+        services.forEach(function(svc) {
+            if (svc.hasPrioritization) {
+                injectDropdownForService(svc.id);
+            }
+        });
+    });
+}
+
+/**
+ * Inject prioritization dropdown for a specific service
+ */
+function injectDropdownForService(serviceId) {
+    // Find the service section and the keyword area
+    var keywordHelp = $('.keyword-help[data-service="' + serviceId + '"]');
+    if (!keywordHelp.length) return;
+
+    // Check if already injected
+    if ($('.immich-prioritization[data-service="' + serviceId + '"]').length) return;
+
+    // Fetch current prioritization settings
+    $.ajax({
+        url: '/keywords/' + serviceId + '/prioritization',
+        dataType: 'json'
+    }).done(function(data) {
+        if (!data.success) return;
+
+        // Build dropdown HTML
+        var html = '<p class="nospace" style="margin-top: 5px;">' +
+            '<label style="margin-right: 5px;">Image order:</label>' +
+            '<select class="immich-prioritization" data-service="' + serviceId + '">';
+
+        for (var mode in data.modes) {
+            var selected = (mode === data.current) ? ' selected' : '';
+            html += '<option value="' + mode + '"' + selected + '>' + data.modes[mode] + '</option>';
+        }
+
+        html += '</select></p>';
+
+        // Insert after the keyword input row
+        var keywordRow = keywordHelp.closest('p');
+        keywordRow.after(html);
+    });
+}
+
+/**
+ * Handle prioritization change
+ */
+$(document).on('change', '.immich-prioritization', function() {
+    var serviceId = $(this).data('service');
+    var mode = $(this).val();
+    var dropdown = $(this);
+
+    dropdown.prop('disabled', true);
+
+    $.ajax({
+        url: '/keywords/' + serviceId + '/prioritization',
+        type: 'POST',
+        contentType: 'application/json',
+        data: JSON.stringify({ mode: mode }),
+        dataType: 'json'
+    }).done(function(data) {
+        if (data.success) {
+            // Brief visual feedback
+            dropdown.css('background-color', '#d4edda');
+            setTimeout(function() {
+                dropdown.css('background-color', '');
+            }, 500);
+        } else {
+            alert('Failed to update prioritization: ' + (data.error || 'Unknown error'));
+        }
+    }).fail(function() {
+        alert('Failed to connect to server');
+    }).always(function() {
+        dropdown.prop('disabled', false);
+    });
+});

--- a/static/template/main.html
+++ b/static/template/main.html
@@ -369,3 +369,5 @@
 <script type="text/javascript" src="/js/main.js"></script>
 <!-- Immich album picker: self-contained UI injected dynamically for services with hasAlbumPicker -->
 <script type="text/javascript" src="/js/immich-albums.js"></script>
+<!-- Immich prioritization: self-contained UI injected dynamically for services with hasPrioritization -->
+<script type="text/javascript" src="/js/immich-prioritization.js"></script>


### PR DESCRIPTION
## Summary
- Add "Image order" dropdown for Immich services
- 5 prioritization modes: none, recent_added, recent_taken, favorites_only, favorites_first
- Sorting/filtering applied server-side in `getImagesFor()`

## Files Changed
| File | Purpose |
|------|---------|
| `svc_immich.py` | Prioritization logic, state storage, capability flag |
| `base.py` | Default `hasPrioritization()` returns False |
| `servicemanager.py` | Flag collection + get/set methods |
| `keywords.py` | `/prioritization` endpoint (GET/POST) |
| `immich-prioritization.js` | Dynamic dropdown injection |
| `main.html` | Single script tag |

## Prioritization Modes
| Mode | Behavior |
|------|----------|
| `none` | Default, rc1 behavior (no sorting) |
| `recent_added` | Sort by `createdAt` descending |
| `recent_taken` | Sort by `fileCreatedAt` descending |
| `favorites_only` | Filter to favorites, fallback to all if none |
| `favorites_first` | Favorites at top, then others |

## Test Plan
- [ ] Dropdown appears for Immich service after keywords are configured
- [ ] Default is "No prioritization"
- [ ] Selecting "Recently added" shows newer uploads more often
- [ ] Selecting "Favorites only" filters to favorites
- [ ] USB/SimpleURL services do NOT show dropdown
- [ ] Setting persists across page refresh

Closes #47