### PR TITLE
feat(backup): add config export/import endpoints (#51)

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -304,7 +304,13 @@ Start `frame.py` with `--emulate` to run without an RPi. The emulator
 mode is useful for iterating on the web UI and photo-service code
 without needing to reflash a card every time.
 
-## HTTP API for display control
+# HTTP API
+
+Photoframe exposes HTTP endpoints for automation and scripting. All
+endpoints require HTTP Basic authentication with the credentials from
+`/root/photoframe_config/http-auth.json`.
+
+## Display control
 
 The display can be turned on and off via HTTP, useful for home
 automation integration (Home Assistant, Domoticz, etc.):
@@ -317,12 +323,35 @@ curl -u photoframe:password http://<pi-ip>:7777/control/screenoff
 curl -u photoframe:password http://<pi-ip>:7777/control/screenon
 ```
 
-These endpoints respect the HTTP authentication configured in
-`/root/photoframe_config/http-auth.json`. Both return JSON:
-`{"screen": "on", "success": true}` or `{"screen": "off", "success": true}`.
+Both return JSON: `{"screen": "on", "success": true}` or
+`{"screen": "off", "success": true}`.
 
 **Note:** This is API groundwork for a future persistent manual override
 feature. Currently, schedule and ambient light sensor rules continue to
 run and may revert the display state on the next evaluation cycle (up to
 60 seconds). A future release will add the ability to hold a manual
 override until explicitly cleared.
+
+## Configuration backup and restore
+
+Export your entire configuration to a `.tar.gz` file:
+
+```bash
+curl -u photoframe:password \
+    http://<pi-ip>:7777/backup/export \
+    -o photoframe-config-backup.tar.gz
+```
+
+Restore configuration from a backup file:
+
+```bash
+curl -u photoframe:password \
+    -F "filename=@photoframe-config-backup.tar.gz" \
+    http://<pi-ip>:7777/backup/import
+```
+
+The import endpoint validates the backup before restoring:
+- Rejects archives containing path traversal (`..` or absolute paths)
+- Requires a `settings.json` file in the archive
+- Creates a `.bak` copy of the current config before overwriting
+- Stops the slideshow during restore and restarts it after

--- a/frame.py
+++ b/frame.py
@@ -153,6 +153,7 @@ class Photoframe:
     self._loadRoute('control', 'RouteControl', self.slideshow, self.timekeeperMgr)
     self._loadRoute('events', 'RouteEvents', self.eventMgr)
     self._loadRoute('debug', 'RouteDebug', self.displayMgr)
+    self._loadRoute('backup', 'RouteBackup', self.settingsMgr, self.slideshow)
 
   def validateSettings(self):
     if not self.settingsMgr.load():

--- a/routes/backup.py
+++ b/routes/backup.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+#
+# This file is part of photoframe (https://github.com/mrworf/photoframe).
+#
+# photoframe is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# photoframe is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with photoframe.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import logging
+import os
+import tarfile
+import tempfile
+import shutil
+from datetime import datetime
+
+from flask import send_file
+from werkzeug.utils import secure_filename
+from .baseroute import BaseRoute
+from modules.path import path
+
+
+class RouteBackup(BaseRoute):
+    def setupex(self, settingsmgr, slideshow):
+        self.settingsmgr = settingsmgr
+        self.slideshow = slideshow
+
+        self.addUrl('/backup/export')
+        self.addUrl('/backup/import').clearMethods().addMethod('POST')
+
+    def handle(self, app):
+        if self.getRequest().method == 'GET':
+            return self._handleExport()
+        elif self.getRequest().method == 'POST':
+            return self._handleImport()
+        self.setAbort(405)
+
+    def _handleExport(self):
+        """Create and return a tar.gz of the config folder."""
+        config_folder = path.CONFIGFOLDER
+
+        if not config_folder.exists():
+            return self.jsonify({'status': False, 'error': 'Config folder does not exist'})
+
+        timestamp = datetime.now().strftime('%Y%m%d-%H%M%S')
+        filename = f'photoframe-config-{timestamp}.tar.gz'
+
+        try:
+            fd, tmppath = tempfile.mkstemp(suffix='.tar.gz')
+            os.close(fd)
+
+            with tarfile.open(tmppath, 'w:gz') as tar:
+                tar.add(str(config_folder), arcname='photoframe_config')
+
+            return send_file(
+                tmppath,
+                mimetype='application/gzip',
+                as_attachment=True,
+                download_name=filename
+            )
+        except Exception as e:
+            logging.exception('Failed to create config backup')
+            return self.jsonify({'status': False, 'error': str(e)})
+
+    def _handleImport(self):
+        """Restore config from uploaded tar.gz."""
+        if 'filename' not in self.getRequest().files:
+            return self.jsonify({'status': False, 'error': 'No file uploaded'})
+
+        file = self.getRequest().files['filename']
+        if file.filename == '':
+            return self.jsonify({'status': False, 'error': 'No file selected'})
+
+        if not file.filename.lower().endswith('.tar.gz'):
+            return self.jsonify({'status': False, 'error': 'File must be a .tar.gz archive'})
+
+        try:
+            fd, tmppath = tempfile.mkstemp(suffix='.tar.gz')
+            os.close(fd)
+            file.save(tmppath)
+
+            if not self._validateTarball(tmppath):
+                os.remove(tmppath)
+                return self.jsonify({'status': False, 'error': 'Invalid backup: missing settings.json or path traversal detected'})
+
+            self.slideshow.stop()
+
+            config_folder = path.CONFIGFOLDER
+            backup_folder = str(config_folder) + '.bak'
+            if os.path.exists(backup_folder):
+                shutil.rmtree(backup_folder)
+            if config_folder.exists():
+                shutil.move(str(config_folder), backup_folder)
+
+            config_folder.mkdir(parents=True, exist_ok=True)
+
+            with tarfile.open(tmppath, 'r:gz') as tar:
+                for member in tar.getmembers():
+                    member.name = member.name.replace('photoframe_config/', '', 1)
+                    if member.name:
+                        tar.extract(member, str(config_folder))
+
+            os.remove(tmppath)
+
+            self.settingsmgr.load()
+            self.slideshow.start()
+
+            return self.jsonify({'status': True, 'message': 'Config restored successfully'})
+
+        except Exception as e:
+            logging.exception('Failed to restore config backup')
+            self.slideshow.start()
+            return self.jsonify({'status': False, 'error': str(e)})
+
+    def _validateTarball(self, filepath):
+        """Validate tarball contains settings.json and no path traversal."""
+        try:
+            has_settings = False
+            with tarfile.open(filepath, 'r:gz') as tar:
+                for member in tar.getmembers():
+                    if '..' in member.name or member.name.startswith('/'):
+                        logging.warning(f'Path traversal detected in backup: {member.name}')
+                        return False
+                    if member.name.endswith('settings.json'):
+                        has_settings = True
+            return has_settings
+        except Exception as e:
+            logging.exception('Failed to validate tarball')
+            return False


### PR DESCRIPTION
## Summary
- Add `GET /backup/export` endpoint to download config as tar.gz
- Add `POST /backup/import` endpoint to restore from uploaded tar.gz
- New `routes/backup.py` handles both operations
- Document HTTP API in MANUAL.md

## Safety measures
- Validates archive contains `settings.json`
- Rejects archives with path traversal (`..` or absolute paths)
- Creates `.bak` copy of current config before overwriting
- Stops slideshow during restore, restarts after

## Test plan
- [ ] Export config via `curl -u photoframe:password http://<ip>:7777/backup/export -o backup.tar.gz`
- [ ] Verify tar.gz contains settings.json and other config files
- [ ] Import config via `curl -u photoframe:password -F "filename=@backup.tar.gz" http://<ip>:7777/backup/import`
- [ ] Verify settings restored and slideshow continues
- [ ] Verify malformed archives rejected (missing settings.json)
- [ ] Verify path traversal rejected

## Changes to shared files

| File | Change | Why not Immich-specific |
|------|--------|------------------------|
| frame.py | +1 line: route registration | Route loader; no backup logic |
| MANUAL.md | +30 lines: API docs | User-facing docs; no code |