### PR TITLE
docs(drivers): expand display driver documentation (#52)

### DIFF
--- a/display-drivers/README.md
+++ b/display-drivers/README.md
@@ -1,16 +1,21 @@
 # Display Drivers
 
-Photoframe now supports uploading and enabling of internal displays for the Raspberry Pi family,
-the only requirement is that it can be supported by the currently used kernel and modules.
+Photoframe supports uploading and enabling of internal displays for the Raspberry Pi family.
+The only requirement is that the display can be supported by the currently used kernel and
+modules.
 
-Since a lot of the smaller displays rely on the built-in fbtft driver, it means that in many
-cases, all you really need is a DeviceTree Overlay, essentially configuration files for the
-device driver so it knows how to talk to the new display.
+Since many smaller displays rely on the built-in fbtft driver, all you often need is a
+DeviceTree Overlay — configuration files that tell the device driver how to talk to the display.
 
-## What's included
+## Bundled drivers
 
-Today, only the waveshare 3.5" IPS (model B) is provided since that was my development system.
-But you can create and share these display "drivers" easily yourself.
+| Driver | Display | Type | Notes |
+|--------|---------|------|-------|
+| `waveshare35a.zip` | Waveshare 3.5" (model A) | SPI/fbtft | 320x480, resistive touch |
+| `waveshare35b.zip` | Waveshare 3.5" IPS (model B) | SPI/fbtft | 320x480, IPS panel, BGR subpixel |
+| `waveshare7.zip` | Waveshare 7" | DPI | 1024x600, no overlay needed |
+
+Upload these via the web UI's "Upload new driver" button, then select the driver from the dropdown.
 
 ## How to write a display driver package
 
@@ -86,6 +91,29 @@ the driver.
 
 Simply upload it again. The old driver will be deleted and replaced with the new one.
 
-## This all seem complicated, do you have an example?
+## This all seems complicated, do you have an example?
 
-Sure, just unzip the `waveshare35b.zip` and look at it for guidance.
+Sure, just unzip `waveshare35b.zip` and look at it for guidance.
+
+## Contributing a new driver
+
+Want to share a driver for a display that isn't bundled? Follow this checklist:
+
+1. **Test thoroughly** on your own hardware first
+2. **Create the driver package** following the format above
+3. **Validate the package** using the validation script:
+   ```bash
+   python3 display-drivers/validate-driver.py your-driver.zip
+   ```
+4. **Open a pull request** with:
+   - The `.zip` file added to `display-drivers/`
+   - A brief description of the display hardware
+   - Confirmation of which Pi model(s) you tested on
+
+### Driver submission checklist
+
+- [ ] INSTALL file present with `[install]` and `[config]` sections
+- [ ] All referenced files exist in the package
+- [ ] No absolute paths in the package (paths are relative to INSTALL)
+- [ ] Tested on real hardware
+- [ ] Works with current Raspberry Pi OS (Bookworm)

--- a/display-drivers/validate-driver.py
+++ b/display-drivers/validate-driver.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Validate a photoframe display driver package.
+
+Usage:
+    python3 validate-driver.py driver.zip
+
+The INSTALL file format allows duplicate keys and bare values (non-standard INI),
+so this validator uses simple text parsing rather than configparser.
+"""
+
+import sys
+import zipfile
+import re
+
+
+def parse_install_file(content):
+    """Parse INSTALL file, returning sections dict."""
+    sections = {}
+    current_section = None
+
+    for line in content.split('\n'):
+        line = line.strip()
+        if not line:
+            continue
+
+        section_match = re.match(r'^\[(\w+)\]$', line)
+        if section_match:
+            current_section = section_match.group(1).lower()
+            sections[current_section] = []
+        elif current_section is not None:
+            sections[current_section].append(line)
+
+    return sections
+
+
+def validate_driver(zippath):
+    errors = []
+    warnings = []
+
+    try:
+        with zipfile.ZipFile(zippath) as z:
+            names = z.namelist()
+
+            install_files = [n for n in names if n.endswith('INSTALL')]
+            if not install_files:
+                errors.append("No INSTALL file found in archive")
+                return errors, warnings
+
+            if len(install_files) > 1:
+                warnings.append(f"Multiple INSTALL files found: {install_files}")
+
+            install_path = install_files[0]
+            install_dir = '/'.join(install_path.split('/')[:-1])
+            if install_dir:
+                install_dir += '/'
+
+            try:
+                content = z.read(install_path).decode('utf-8')
+            except Exception as e:
+                errors.append(f"Cannot read INSTALL file: {e}")
+                return errors, warnings
+
+            sections = parse_install_file(content)
+
+            if 'install' not in sections:
+                errors.append("Missing [install] section in INSTALL file")
+
+            if 'config' not in sections:
+                errors.append("Missing [config] section in INSTALL file")
+
+            if 'install' in sections:
+                for line in sections['install']:
+                    if '=' in line:
+                        src_file = line.split('=')[0].strip()
+                        full_path = install_dir + src_file
+                        if full_path not in names and src_file not in names:
+                            errors.append(f"File referenced in [install] not found: {src_file}")
+
+            if 'config' in sections and not sections['config']:
+                warnings.append("[config] section is empty")
+
+            for name in names:
+                if name.startswith('/') or '..' in name:
+                    errors.append(f"Suspicious path in archive: {name}")
+
+    except zipfile.BadZipFile:
+        errors.append("Not a valid ZIP file")
+    except Exception as e:
+        errors.append(f"Error reading archive: {e}")
+
+    return errors, warnings
+
+
+def main():
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <driver.zip>")
+        sys.exit(1)
+
+    zippath = sys.argv[1]
+    print(f"Validating: {zippath}")
+    print()
+
+    errors, warnings = validate_driver(zippath)
+
+    if warnings:
+        print("Warnings:")
+        for w in warnings:
+            print(f"  - {w}")
+        print()
+
+    if errors:
+        print("Errors:")
+        for e in errors:
+            print(f"  - {e}")
+        print()
+        print("FAILED: Driver package has errors")
+        sys.exit(1)
+    else:
+        print("OK: Driver package is valid")
+        sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- Add table of bundled drivers (waveshare35a, waveshare35b, waveshare7) with specs
- Add "Contributing a new driver" section with submission checklist
- Add `validate-driver.py` script to validate driver packages before submission

## Test plan
- [ ] Verify `validate-driver.py` passes on all bundled drivers
- [ ] Verify documentation renders correctly on GitHub

## Files changed
| File | Change |
|------|--------|
| `display-drivers/README.md` | Updated docs with driver table + contributing section |
| `display-drivers/validate-driver.py` | NEW: Package validation script |